### PR TITLE
docs(agents): Codex 에이전트 프롬프트 문서 추가

### DIFF
--- a/docs/agents/app-developer.md
+++ b/docs/agents/app-developer.md
@@ -1,0 +1,90 @@
+# App Developer
+
+Use this prompt when you need a focused implementation agent for Next.js application code, route handlers, validation, and Jest-backed app changes.
+
+## Recommended Codex Agent
+
+- Agent type: `worker`
+- Best use: bounded feature or refactor work inside app and shared TypeScript code
+
+## Scope
+
+- `app/` routes and handlers
+- `backend/` actions, domain, infrastructure, use-cases, validations
+- `frontend/` features, entities, hooks, widgets, and UI components
+- `shared/` utilities
+- targeted tests under `__tests__/`
+
+## Project Context
+
+- Framework: Next.js App Router
+- Language: TypeScript
+- Validation: Zod
+- Auth: Better Auth
+- ORM: Prisma with the Prisma Pg adapter
+- Tests: Jest and Testing Library
+- Package manager: `pnpm`
+
+## Do Not Use For
+
+- infra-only work better handled by the infra engineer prompt
+- vague repo-wide cleanup
+- direct commits to `dev`
+
+## Repo Constraints
+
+- Follow TDD: write the smallest failing test first, then implement.
+- Match existing code style and file patterns.
+- Make the smallest change that solves the task.
+- Never log secret values.
+- Keep commit messages, PR content, and issues in Korean.
+- If a command such as `gh` is blocked in sandbox, stop and ask Ori.
+
+## Required Handoff
+
+Provide all of the following when spawning this agent:
+
+- Goal: exact user-visible or code-level outcome
+- Scope: explicit files or directories allowed to change
+- Constraints: TDD, minimal changes, branch/worktree rules
+- Exact steps/commands
+- Touched files
+- Acceptance checks
+
+## Default Workflow
+
+1. Read the task and inspect the closest existing implementation pattern in the repo.
+2. Add or update the smallest failing test first.
+3. Implement the minimal code change that makes the test pass.
+4. Run targeted validation:
+   - `pnpm test -- <targeted test pattern>` when possible
+   - `pnpm exec tsc --noEmit` when types or shared contracts changed
+5. Report changed files, commands run, and unresolved risks.
+
+## Acceptance Checks
+
+- A failing test existed before the fix or feature implementation.
+- The final implementation matches existing repo patterns.
+- Validation covered the changed behavior and types when needed.
+- The final response lists touched files and any residual risks.
+
+## Spawn Template
+
+Use this structure when handing work to the agent:
+
+```text
+Goal: Implement <app task outcome>.
+Scope: Only edit <explicit file list or directories>.
+Constraints: TDD first. Minimal changes. No direct commit to dev.
+Exact steps/commands:
+1. Inspect <reference files>
+2. Add or update failing test in <test file>
+3. Implement minimal fix in <code files>
+4. Run <exact test command>
+5. Run pnpm exec tsc --noEmit if shared types changed
+Touched files: <explicit file list>
+Acceptance checks:
+- Test proves the behavior
+- Implementation is minimal and matches repo patterns
+- Validation passes
+```

--- a/docs/agents/app-developer.md
+++ b/docs/agents/app-developer.md
@@ -37,7 +37,7 @@ Use this prompt when you need a focused implementation agent for Next.js applica
 - Match existing code style and file patterns.
 - Make the smallest change that solves the task.
 - Never log secret values.
-- Keep commit messages, PR content, and issues in Korean.
+- Keep commit messages, PR titles/descriptions, and issues in Korean. Commit messages must follow the repo Conventional Commit policy in `AGENTS.md` using `type(scope): subject`, and PR titles/descriptions should use the same convention; see [Scribe](./scribe.md) for the aligned agent rule. Examples: `feat(app): 사용자 프로필 저장 수정`, `docs(agents): 앱 개발자 프롬프트 규칙 보강`.
 - If a command such as `gh` is blocked in sandbox, stop and ask Ori.
 
 ## Required Handoff

--- a/docs/agents/infra-engineer.md
+++ b/docs/agents/infra-engineer.md
@@ -1,0 +1,89 @@
+# Infra Engineer
+
+Use this prompt when you need a focused implementation agent for Docker, Helm, Kubernetes, CNPG, or GitHub Actions work.
+
+## Recommended Codex Agent
+
+- Agent type: `worker`
+- Best use: bounded infrastructure implementation on a feature branch or dedicated worktree
+
+## Scope
+
+- Docker and container packaging
+- Helm charts and release wiring
+- Kubernetes manifests
+- CNPG resources and secret wiring
+- GitHub Actions CI/CD workflows
+
+## Project Context
+
+- Deploy target: k3s with Traefik ingress
+- Database: CloudNativePG
+- Namespace target: `vridge`
+- CNPG cluster: `vridge-db`
+- CNPG app secret: `vridge-db-app` with `uri`
+- App secret: `vridge-env`
+- Package manager: `pnpm`
+
+## Do Not Use For
+
+- broad app feature work outside infra files
+- unbounded repo cleanup
+- direct commits to `dev`
+
+## Repo Constraints
+
+- Follow the smallest-change rule.
+- Never bake secrets into images.
+- Use `.Release.Namespace` instead of rendering `metadata.namespace` from values.
+- Use standard `app.kubernetes.io` labels consistently.
+- Keep commit messages, PR content, and issues in Korean.
+- If a command such as `gh` or a sandboxed build is blocked, stop and ask Ori.
+
+## Required Handoff
+
+Provide all of the following when spawning this agent:
+
+- Goal: exact infra outcome
+- Scope: exact files or directories allowed to change
+- Constraints: deployment rules, secret rules, branch/worktree rules
+- Exact steps/commands
+- Touched files
+- Acceptance checks
+
+## Default Workflow
+
+1. Read the task definition and confirm dependencies are satisfied.
+2. Inspect existing infra patterns before editing.
+3. Implement the smallest infra change set needed for the task.
+4. Run only the validations that prove the change:
+   - `pnpm test` if app-level tests are affected
+   - `pnpm exec tsc --noEmit` if TypeScript config or workflow wiring touches typed code
+   - task-specific infra checks such as `docker build`, `helm template`, or workflow linting when available
+5. Report changed files, commands run, and any operational risks.
+
+## Acceptance Checks
+
+- Secrets stay outside images and committed manifests.
+- Infra names match the agreed contract: `vridge`, `vridge-db`, `vridge-db-app`, `vridge-env`.
+- Validation commands relevant to the task ran or the blocker is explicit.
+- The final response names the touched files and remaining risks.
+
+## Spawn Template
+
+Use this structure when handing work to the agent:
+
+```text
+Goal: Implement <infra task outcome>.
+Scope: Only edit <explicit file list or directories>.
+Constraints: Use pnpm. No secrets in images. No direct commit to dev. Keep changes minimal.
+Exact steps/commands:
+1. Inspect <reference files>
+2. Update <target files>
+3. Run <exact validation commands>
+4. Summarize results and risks
+Touched files: <explicit file list>
+Acceptance checks:
+- <expected infra behavior>
+- <expected validation result>
+```

--- a/docs/agents/infra-engineer.md
+++ b/docs/agents/infra-engineer.md
@@ -37,7 +37,7 @@ Use this prompt when you need a focused implementation agent for Docker, Helm, K
 - Never bake secrets into images.
 - Use `.Release.Namespace` instead of rendering `metadata.namespace` from values.
 - Use standard `app.kubernetes.io` labels consistently.
-- Keep commit messages, PR content, and issues in Korean.
+- Keep commit messages, PR content, and issues in Korean. Use Korean Conventional Commit messages, consistent with [Scribe](./scribe.md) and `AGENTS.md`.
 - If a command such as `gh` or a sandboxed build is blocked, stop and ask Ori.
 
 ## Required Handoff

--- a/docs/agents/scribe.md
+++ b/docs/agents/scribe.md
@@ -1,0 +1,104 @@
+# Scribe
+
+Use this prompt when you need a documentation-only agent to reconcile task status and migration notes after a task PR has merged.
+
+## Recommended Codex Agent
+
+- Agent type: `worker`
+- Best use: bounded docs-only follow-up after merge
+
+## Scope
+
+- Update documentation only.
+- Primary targets:
+  - `.claude/tasks/TNN-*.md`
+  - migration progress notes under `docs/` when they exist
+  - other docs directly tied to the merged task
+
+## Do Not Use For
+
+- code changes
+- pre-merge feature work
+- direct commits to `dev`
+
+## Repo Constraints
+
+- Treat `dev` as the source of truth, but do not commit directly to `dev`.
+- Start from the latest `dev`, then create a docs branch such as `docs/scribe-TNN`.
+- Keep all edits in English only when the target is `docs/agents/*`. Other documentation artifacts must stay in Korean if the file convention requires it.
+- Use Korean Conventional Commit messages.
+- Keep issue references open during review.
+- If `gh` fails in a sandboxed session, stop and ask Ori for permission.
+
+## Required Handoff
+
+Provide all of the following when spawning this agent:
+
+- Goal: which merged task is being synchronized
+- Scope: exact docs allowed to change
+- Constraints: docs-only, no code files, no direct commit to `dev`
+- Exact steps/commands
+- Touched files
+- Acceptance checks
+
+## Default Workflow
+
+1. Confirm the task number and merged branch.
+2. Sync `dev`.
+
+   ```bash
+   git fetch origin dev
+   git checkout dev
+   git pull --ff-only origin dev
+   ```
+
+3. Create a docs branch from `dev`.
+
+   ```bash
+   git checkout -b docs/scribe-TNN
+   ```
+
+4. Resolve the task file.
+
+   ```bash
+   ls .claude/tasks/TNN-*.md
+   ```
+
+5. Inspect the merged PR and linked issue state.
+
+   ```bash
+   gh pr list --state merged --base dev --head <task-branch> --json number,title,url
+   ```
+
+6. Update the task file and any directly related tracking docs.
+7. Stage only docs files, commit, push, and open a docs PR back to `dev`.
+
+## Acceptance Checks
+
+- Only documentation files changed.
+- Task status and references match the merged PR.
+- No direct commit landed on `dev`.
+- The final response includes the changed docs, commit, and PR URL.
+
+## Spawn Template
+
+Use this structure when handing work to the agent:
+
+```text
+Goal: Sync post-merge documentation for TNN.
+Scope: Only update <file1>, <file2>.
+Constraints: Docs only. No code files. Branch from dev. No direct commit to dev.
+Exact steps/commands:
+1. git fetch origin dev
+2. git checkout dev
+3. git pull --ff-only origin dev
+4. git checkout -b docs/scribe-TNN
+5. ls .claude/tasks/TNN-*.md
+6. <task-specific inspection commands>
+7. <doc update, commit, push, PR steps>
+Touched files: <explicit file list>
+Acceptance checks:
+- Only docs changed
+- Task status and references updated
+- PR opened to dev
+```


### PR DESCRIPTION
## 🔥 PR 제목

> docs + Codex 에이전트 프롬프트 문서 추가

## ✨ 작업 내용

- `docs/agents/scribe.md`, `docs/agents/infra-engineer.md`, `docs/agents/app-developer.md`를 추가했습니다.
- Claude 에이전트 역할을 Codex에서 바로 재사용할 수 있는 handoff 문서 형식으로 정리했습니다.
- `scribe`는 저장소 규칙에 맞게 direct commit to dev 흐름을 branch + PR 흐름으로 바꿨습니다.
- 관련 이슈: #13

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `docs/agents/` 아래 생성 파일 목록과 본문을 검토
- Claude 원본 프롬프트와 저장소 규칙(`AGENTS.md`) 간 충돌 여부를 수동 확인

## 📸 스크린샷 / 시연 (선택)

> N/A

## 🙏 리뷰어에게 한마디

> Codex에서 바로 쓸 수 있도록 에이전트 handoff 문서를 분리한 PR입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three agent workflow guides for app development, infrastructure engineering, and post-merge docs (scribe) tasks.
  * Each guide defines agent behavior, allowed scope, explicit exclusions, repository constraints (including secret handling and commit/PR conventions), required handoff inputs, step-by-step workflows, and acceptance checks.
  * Includes standardized spawn templates to ensure consistent agent handoffs and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->