### PR TITLE
feat(codex): 작업 시작 마무리 스킬 추가

### DIFF
--- a/.agents/skills/finish-task/SKILL.md
+++ b/.agents/skills/finish-task/SKILL.md
@@ -19,8 +19,6 @@ Use this skill when Ori wants to wrap up a migration task that is already implem
    - `task`
    - `title`
    - `branch`
-   - `labels`
-   - `milestone`
    - `issue`
 
 3. Confirm the current branch matches the task branch before mutating git state.
@@ -80,7 +78,7 @@ Use this skill when Ori wants to wrap up a migration task that is already implem
    - Include:
      - implementation summary
      - validation commands that passed
-     - linked issue reference for context
+     - linked issue reference for context when `issue` is present
 
 9. Report the result.
    - Print the PR URL.

--- a/.agents/skills/finish-task/SKILL.md
+++ b/.agents/skills/finish-task/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: finish-task
+description: Finish work from `.claude/tasks/TNN-*.md` by running validation, creating a Korean Conventional Commit, pushing the task branch, and opening a PR to `dev`.
+---
+
+# Finish Task
+
+Use this skill when Ori wants to wrap up a migration task that is already implemented on a feature branch or task worktree.
+
+## Workflow
+
+1. Resolve the task file.
+
+   ```bash
+   ls .claude/tasks/T$ARGUMENTS-*.md
+   ```
+
+2. Read the task file and extract:
+   - `task`
+   - `title`
+   - `branch`
+   - `labels`
+   - `milestone`
+   - `issue`
+
+3. Confirm the current branch matches the task branch before mutating git state.
+
+   ```bash
+   git branch --show-current
+   ```
+
+   - If the current branch does not match the task branch, stop and report the mismatch.
+
+4. Run required validation before staging or pushing.
+
+   ```bash
+   pnpm test
+   pnpm exec tsc --noEmit
+   ```
+
+   - Stop on any failure and report the failing command output.
+   - In sandboxed sessions, treat `gh` failures as permission blockers and stop for Ori.
+
+5. Review the working tree and branch history.
+
+   ```bash
+   git status --short
+   git log --oneline origin/dev..HEAD
+   ```
+
+   - If there are no working tree changes and no task commits ahead of `dev`, report that there is nothing to finish.
+
+6. Stage and commit the task changes.
+
+   ```bash
+   git add -A
+   ```
+
+   - Use a Korean Conventional Commit message.
+   - Commit type rule:
+     - `docs`: docs-only task changes
+     - `chore`: workflow-only maintenance
+     - otherwise `feat`
+   - Preferred message pattern:
+
+   ```text
+   {type}(task): T$ARGUMENTS 작업 마무리
+   ```
+
+7. Push the task branch.
+
+   ```bash
+   git push -u origin HEAD
+   ```
+
+8. Open a PR to `dev`.
+   - Use `.github/pull_request_template.md` if the GitHub CLI does not apply it automatically.
+   - Keep the linked issue open during review; do not close it in the PR body.
+   - Use the task title for the PR title.
+   - Include:
+     - implementation summary
+     - validation commands that passed
+     - linked issue reference for context
+
+9. Report the result.
+   - Print the PR URL.
+   - Include the commit created, or say that no commit was needed.
+
+## Guardrails
+
+- Do not update tracking docs or task status as part of `finish-task`.
+- Do not bypass failing tests or type checks.
+- Do not commit unrelated changes.

--- a/.agents/skills/finish-task/SKILL.md
+++ b/.agents/skills/finish-task/SKILL.md
@@ -42,18 +42,22 @@ Use this skill when Ori wants to wrap up a migration task that is already implem
 5. Review the working tree and branch history.
 
    ```bash
-   git status --short
-   git log --oneline origin/dev..HEAD
+   git status --porcelain
+   git rev-list --count origin/dev..HEAD
    ```
 
-   - If there are no working tree changes and no task commits ahead of `dev`, report that there is nothing to finish.
+   - Treat a non-empty `git status --porcelain` result as pending working tree changes.
+   - Treat the `git rev-list --count` result as the number of task commits already ahead of `dev`.
+   - If there are no working tree changes and the ahead count is `0`, report that there is nothing to finish.
+   - If there are no working tree changes and the ahead count is greater than `0`, skip staging and commit creation and report that there is nothing new to commit because the branch is already ahead of `dev`.
 
-6. Stage and commit the task changes.
+6. Stage and commit the task changes only when working tree changes exist.
 
    ```bash
    git add -A
    ```
 
+   - Do not run `git add -A` or create a commit when `git status --porcelain` is empty.
    - Use a Korean Conventional Commit message.
    - Commit type rule:
      - `docs`: docs-only task changes
@@ -82,7 +86,7 @@ Use this skill when Ori wants to wrap up a migration task that is already implem
 
 9. Report the result.
    - Print the PR URL.
-   - Include the commit created, or say that no commit was needed.
+   - Include the commit created, or say that no commit was needed because the branch was already ahead of `dev`.
 
 ## Guardrails
 

--- a/.agents/skills/finish-task/agents/openai.yaml
+++ b/.agents/skills/finish-task/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Finish Task"
+  short_description: "Validate, commit, push, and open a task PR"
+  default_prompt: "Use $finish-task to wrap up task T01, run validation, and open a PR to `dev` with the repo template."

--- a/.agents/skills/start-task/SKILL.md
+++ b/.agents/skills/start-task/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: start-task
+description: Start work from `.claude/tasks/TNN-*.md` by checking dependencies, syncing `dev`, preferring a `git worktree`, surfacing the linked issue, and summarizing the exact implementation scope.
+---
+
+# Start Task
+
+Use this skill when Ori wants to begin one of the migration tasks tracked in `.claude/tasks/`.
+
+## Workflow
+
+1. Resolve the task file.
+
+   ```bash
+   ls .claude/tasks/T$ARGUMENTS-*.md
+   ```
+
+2. Read the task file and extract:
+   - `task`
+   - `title`
+   - `branch`
+   - `depends_on`
+   - `issue`
+   - `agent`
+   - `status`
+
+3. Stop if the task is already complete or otherwise not ready to start.
+   - If `status: done`, report that the task is already marked complete.
+   - If the task file is missing required frontmatter, stop and report the missing field.
+
+4. Check dependencies against `dev`.
+   - For each dependency in `depends_on`, verify a merged PR exists on `dev`.
+
+   ```bash
+   gh pr list --state merged --base dev --search "T${dep}" --limit 1
+   ```
+
+   - If any dependency is not merged, stop and report the blocking task.
+   - In sandboxed sessions, treat `gh` failures as permission blockers and stop for Ori.
+
+5. Ensure issue tracking is in place before implementation.
+   - If `issue` is present, show it:
+
+   ```bash
+   gh issue view {issue number}
+   ```
+
+   - If `issue` is missing, stop and create a feature issue from `.github/ISSUE_TEMPLATE/feature_request.md` before implementing.
+
+6. Sync the base branch using the repo rule set.
+
+   ```bash
+   git fetch origin dev
+   git checkout dev
+   git pull --ff-only origin dev
+   ```
+
+   - If the fast-forward pull fails, stop and ask Ori.
+
+7. Prefer a worktree-based task checkout.
+   - Use the task branch from frontmatter.
+   - Use a deterministic local path so the worktree is easy to locate.
+
+   ```bash
+   git worktree add "../vridge-T$ARGUMENTS" -b "{branch}" dev
+   ```
+
+   - If the branch already exists locally, attach the worktree without recreating the branch.
+   - Only fall back to a normal branch checkout if worktree setup is genuinely blocked and that exception is explicit in the session.
+
+8. Summarize the task before implementation starts.
+   - Print the task title.
+   - Summarize goal, requirements, testing expectations, and done criteria.
+   - If `agent` is present, print the recommended Codex handoff doc:
+     - `app-developer` -> `docs/agents/app-developer.md`
+     - `infra-engineer` -> `docs/agents/infra-engineer.md`
+     - `scribe` -> `docs/agents/scribe.md`
+
+## Output Contract
+
+The final response should leave the implementing session with:
+
+- the resolved task file path
+- dependency status
+- issue status
+- the branch or worktree that was prepared
+- a concise implementation brief
+- the recommended agent doc, if one exists

--- a/.agents/skills/start-task/agents/openai.yaml
+++ b/.agents/skills/start-task/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Start Task"
+  short_description: "Prepare a tracked task and summarize the scope"
+  default_prompt: "Use $start-task to prepare work for task T01 from `.claude/tasks/` and summarize the exact implementation scope."


### PR DESCRIPTION
## 🔥 PR 제목

> feat + Codex 작업 시작/마무리 스킬 추가

## ✨ 작업 내용

- `.agents/skills/start-task`와 `.agents/skills/finish-task`를 추가했습니다.
- Claude 작업 흐름을 Codex 스킬 형식으로 옮기되, `AGENTS.md` 규칙에 맞게 worktree 기반 시작 흐름과 PR 마무리 흐름으로 정리했습니다.
- 각 스킬에 `agents/openai.yaml` 메타데이터를 추가했습니다.
- 관련 이슈: #12

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- Ruby YAML 파서로 `agents/openai.yaml` 두 파일이 정상 파싱되는지 확인
- 스킬 본문을 재검토하여 `AGENTS.md`와 충돌하는 지시가 없는지 확인

## 📸 스크린샷 / 시연 (선택)

> N/A

## 🙏 리뷰어에게 한마디

> Claude 기반 작업 스킬을 Codex 환경 규칙에 맞춰 옮긴 PR입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task initialization workflow: prepares a tracked task, validates dependencies and issue/PR status, syncs and readies a dedicated branch/worktree, and summarizes implementation scope before work begins.
  * Task completion workflow: runs validations, creates a standardized commit message in Korean, pushes the branch, and opens a pull request to the development branch with a generated PR body and linked issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->