### PR TITLE
chore: scribe 에이전트 dev 직접 커밋 방지

### DIFF
--- a/.claude/agents/scribe.md
+++ b/.claude/agents/scribe.md
@@ -1,9 +1,9 @@
 ---
 name: scribe
 description: >
-  Documentation maintenance agent. Runs on dev branch after task PRs merge
-  to update task status, progress tracking, and result summaries.
-  Never runs on feature branches.
+  Documentation maintenance agent. After task PRs merge, creates a docs branch
+  from dev to update task status, progress tracking, and result summaries.
+  Opens a PR to dev — never commits directly to dev.
 model: haiku
 tools:
   - Read
@@ -22,14 +22,13 @@ Post-merge documentation synchronization agent.
 ## Why This Agent Exists
 
 When multiple feature branches modify the same documentation files (status tables,
-result sections), rebase conflicts are inevitable. The scribe updates documentation
-**only on the dev branch** after merges, eliminating this problem at the source.
+result sections), rebase conflicts are inevitable. The scribe centralizes doc updates
+after merges, reducing this problem at the source.
 
 ## When to Run
 
 - Immediately **after** a task PR merges into dev
 - Invoked via the `/scribe` skill
-- **Never** runs on feature branches
 
 ## Responsibilities
 
@@ -40,7 +39,8 @@ result sections), rebase conflicts are inevitable. The scribe updates documentat
 
 ## Rules
 
-- Only operate on the dev branch. If called from a feature branch, stop immediately.
+- Start from the latest dev branch, but never commit directly to dev.
+- Create a `docs/scribe-T{N}` branch for changes and open a PR to dev.
 - Bundle all documentation changes into a single commit.
 - Commit message format: `docs: T{N} 결과 반영`
 - Do not modify code files. Documentation files only.

--- a/.claude/skills/scribe/SKILL.md
+++ b/.claude/skills/scribe/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: scribe
-description: Post-merge doc sync — updates task status and progress tracking on dev
+description: Post-merge doc sync — updates task status and progress tracking via PR to dev
 argument-hint: '<task-number> (e.g., 01, 02, ...10)'
-allowed-tools: Bash(git *), Read, Glob, Grep, Write, Edit
+allowed-tools: Bash(git *), Bash(gh *), Read, Glob, Grep, Write, Edit
 ---
 
 Run post-merge documentation sync for task T$ARGUMENTS.
 
-1. **Verify we are on dev**:
+1. **Ensure we start from latest dev**:
 
+   ```bash
+   git fetch origin dev
+   git checkout dev
+   git merge --ff-only origin/dev
    ```
-   git branch --show-current
-   ```
 
-   If the current branch is not `dev`, **stop immediately**:
+   If ff-only fails, **stop immediately** and report the error.
 
-   > Error: Scribe must run on dev branch. Current branch: {branch}. Switch to dev first.
+2. **Create a docs branch**:
 
-2. **Pull latest dev**:
-
-   ```
-   git pull origin dev
+   ```bash
+   git checkout -b docs/scribe-T$ARGUMENTS
    ```
 
 3. **Find the task file**:
@@ -52,10 +52,11 @@ Run post-merge documentation sync for task T$ARGUMENTS.
    git commit -m "docs: T$ARGUMENTS 결과 반영"
    ```
 
-8. **Push to dev**:
+8. **Push branch and open PR**:
 
-   ```
-   git push origin dev
+   ```bash
+   git push -u origin docs/scribe-T$ARGUMENTS
+   gh pr create --base dev --title "docs: T$ARGUMENTS 결과 반영" --body "T$ARGUMENTS 태스크 완료에 따른 문서 동기화"
    ```
 
-9. **Report** — print what was updated.
+9. **Report** — print the PR URL and what was updated.


### PR DESCRIPTION
## Summary
- scribe 에이전트/스킬이 dev 브랜치에 직접 커밋하던 워크플로우를 `docs/scribe-T{N}` 브랜치 생성 + PR 방식으로 변경
- CLAUDE.md의 "dev에 직접 커밋 금지" 규칙과 일관성 확보
- 에이전트 설명, 규칙, 스킬 워크플로우 모두 업데이트

## Test plan
- [ ] `/scribe 01` 등으로 실행 시 dev가 아닌 `docs/scribe-T01` 브랜치가 생성되는지 확인
- [ ] PR이 dev를 base로 자동 생성되는지 확인
- [ ] dev 브랜치에 직접 커밋이 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)