### PR TITLE
[T03] Health endpoints for Kubernetes probes

### DIFF
--- a/__tests__/app/healthz/route.test.ts
+++ b/__tests__/app/healthz/route.test.ts
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/healthz/route';
+
+describe('GET /healthz', () => {
+  it('200 반환', async () => {
+    const response = GET();
+    expect(response.status).toBe(200);
+  });
+
+  it('{ status: "ok" } 반환', async () => {
+    const response = GET();
+    const body = await response.json();
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/__tests__/app/readyz/route.test.ts
+++ b/__tests__/app/readyz/route.test.ts
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/readyz/route';
+
+describe('GET /readyz', () => {
+  it('200 반환', async () => {
+    const response = GET();
+    expect(response.status).toBe(200);
+  });
+
+  it('{ status: "ok" } 반환', async () => {
+    const response = GET();
+    const body = await response.json();
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/app/healthz/route.ts
+++ b/app/healthz/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/app/readyz/route.ts
+++ b/app/readyz/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -19,6 +19,8 @@ function isPublicPath(pathname: string): boolean {
 
   return (
     pathname === '/' ||
+    pathname === '/healthz' ||
+    pathname === '/readyz' ||
     pathname.startsWith('/jobs') ||
     pathname.startsWith('/announcements') ||
     isPublicCandidatePath ||


### PR DESCRIPTION
## 작업 내용

- `GET /healthz` 엔드포인트 추가 — 프로세스 활성 시 `{ "status": "ok" }` (200) 반환
- `GET /readyz` 엔드포인트 추가 — HTTP 트래픽 처리 가능 시 `{ "status": "ok" }` (200) 반환
- `proxy.ts` 공개 경로에 `/healthz`, `/readyz` 등록 — 인증 없이 통과
- Phase 1: DB 쿼리 없는 경량 readiness 로직

## 테스트

- pnpm test 통과 (544 tests, 87 suites)
- tsc --noEmit 통과

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoints to support application monitoring and readiness verification in production environments.

* **Tests**
  * Added test suites for health check endpoints to validate HTTP status codes and response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->