### PR TITLE
feat(skill): address-review — CodeRabbit 리뷰 자동 처리 스킬

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -31,7 +31,7 @@ gh api /repos/$REPO/pulls/$PR/reviews \
 python3 -c "
 import sys, re
 body = sys.stdin.read()
-m = re.search(r'Prompt for all review comments.*?\x60\x60\x60\n(.*?)\x60\x60\x60', body, re.DOTALL)
+m = re.search(r'Prompt for all review comments.*?\x60\x60\x60\w*\r?\n(.*?)\x60\x60\x60', body, re.DOTALL)
 print(m.group(1).strip() if m else '')
 "
 ```
@@ -90,7 +90,7 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
    python3 -c "
    import sys, re
    body = sys.stdin.read()
-   m = re.search(r'Prompt for all review comments.*?\x60\x60\x60\n(.*?)\x60\x60\x60', body, re.DOTALL)
+   m = re.search(r'Prompt for all review comments.*?\x60\x60\x60\w*\r?\n(.*?)\x60\x60\x60', body, re.DOTALL)
    print(m.group(1).strip() if m else '')
    "
    ```
@@ -122,6 +122,7 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
      RESULT=$(gh api /repos/{REPO}/pulls/{PR}/reviews \
        --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id:.id,state:.state}')
      NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'])")
+     NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['state'])")
      [ "$NEW_ID" != "$REVIEW_ID" ] && break
    done
    [ "$NEW_ID" = "$REVIEW_ID" ] && TIMEOUT=1

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -56,8 +56,8 @@ for i in $(seq 1 6); do
   sleep 30
   RESULT=$(gh api /repos/$REPO/pulls/$PR/reviews \
     --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state}')
-  NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
-  NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'])")
+  NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'] if d else '')")
+  NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'] if d else '')")
   [ "$NEW_ID" != "$PREV_ID" ] && break
 done
 [ "$NEW_ID" = "$PREV_ID" ] && TIMEOUT=1
@@ -121,8 +121,8 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
      sleep 30
      RESULT=$(gh api /repos/{REPO}/pulls/{PR}/reviews \
        --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id:.id,state:.state}')
-     NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'])")
-     NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['state'])")
+     NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'] if d else '')")
+     NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['state'] if d else '')")
      [ "$NEW_ID" != "$REVIEW_ID" ] && break
    done
    [ "$NEW_ID" = "$REVIEW_ID" ] && TIMEOUT=1

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -22,8 +22,10 @@ PR=$(gh pr view --json number --jq .number)
 
 ```bash
 gh api /repos/$REPO/pulls/$PR/reviews \
-  --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state, body: .body}'
+  --jq '([.[] | select(.user.login | contains("coderabbitai"))] | last) // empty | {id: .id, state: .state, body: .body}'
 ```
+
+Returns nothing (empty string) when there are no CodeRabbit reviews — callers must guard with `[ -z "$RESULT" ]`.
 
 **Extract the AI prompt block** from a review body (pipe body text into this):
 
@@ -55,9 +57,10 @@ TIMEOUT=0
 for i in $(seq 1 6); do
   sleep 30
   RESULT=$(gh api /repos/$REPO/pulls/$PR/reviews \
-    --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state}')
-  NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'] if d else '')")
-  NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'] if d else '')")
+    --jq '([.[] | select(.user.login | contains("coderabbitai"))] | last) // empty | {id: .id, state: .state}')
+  if [ -z "$RESULT" ]; then NEW_ID=""; NEW_STATE=""; continue; fi
+  NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+  NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'])")
   [ "$NEW_ID" != "$PREV_ID" ] && break
 done
 [ "$NEW_ID" = "$PREV_ID" ] && TIMEOUT=1
@@ -79,8 +82,9 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
 **Each round:**
 
 1. Fetch the latest CodeRabbit review:
-   `gh api /repos/{REPO}/pulls/{PR}/reviews --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state, body: .body}'`
-   Save `id` as REVIEW_ID and `state` as STATE.
+   `gh api /repos/{REPO}/pulls/{PR}/reviews --jq '([.[] | select(.user.login | contains("coderabbitai"))] | last) // empty | {id: .id, state: .state, body: .body}'`
+   If the result is empty (no CodeRabbit reviews yet): stop. Report "No CodeRabbit review found."
+   Otherwise save `id` as REVIEW_ID and `state` as STATE.
 
 2. If STATE is `APPROVED`: stop. Report "CodeRabbit approved after N round(s). ✓"
 
@@ -120,9 +124,10 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
    for i in $(seq 1 6); do
      sleep 30
      RESULT=$(gh api /repos/{REPO}/pulls/{PR}/reviews \
-       --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id:.id,state:.state}')
-     NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'] if d else '')")
-     NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['state'] if d else '')")
+       --jq '([.[] | select(.user.login | contains("coderabbitai"))] | last) // empty | {id:.id,state:.state}')
+     if [ -z "$RESULT" ]; then NEW_ID=""; NEW_STATE=""; continue; fi
+     NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'])")
+     NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['state'])")
      [ "$NEW_ID" != "$REVIEW_ID" ] && break
    done
    [ "$NEW_ID" = "$REVIEW_ID" ] && TIMEOUT=1

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: '[--background]'
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Agent
 ---
 
+# address-review
+
 Fix all outstanding CodeRabbit review findings on the current PR.
 
 ## Setup (run once)
@@ -17,12 +19,14 @@ PR=$(gh pr view --json number --jq .number)
 ## Shared helpers
 
 **Fetch latest CodeRabbit review** (returns JSON with `id`, `state`, `body`):
+
 ```bash
 gh api /repos/$REPO/pulls/$PR/reviews \
   --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state, body: .body}'
 ```
 
 **Extract the AI prompt block** from a review body (pipe body text into this):
+
 ```bash
 python3 -c "
 import sys, re
@@ -33,18 +37,21 @@ print(m.group(1).strip() if m else '')
 ```
 
 **Reply to all inline comments from a review** after committing:
+
 ```bash
 SHA=$(git rev-parse --short HEAD)
 REVIEW_ID=<id from fetch step>
 for ID in $(gh api /repos/$REPO/pulls/$PR/reviews/$REVIEW_ID/comments --jq '.[].id'); do
   gh api /repos/$REPO/pulls/comments/$ID/replies -X POST \
-    -f body="${SHA}에서 반영했습니다."
+    -f body="Applied in ${SHA}."
 done
 ```
 
 **Poll for a new CodeRabbit review** (call after push; pass previous review ID):
+
 ```bash
 PREV_ID=<id before push>
+TIMEOUT=0
 for i in $(seq 1 6); do
   sleep 30
   RESULT=$(gh api /repos/$REPO/pulls/$PR/reviews \
@@ -53,7 +60,8 @@ for i in $(seq 1 6); do
   NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'])")
   [ "$NEW_ID" != "$PREV_ID" ] && break
 done
-# NEW_STATE and NEW_ID are now set to the latest review
+[ "$NEW_ID" = "$PREV_ID" ] && TIMEOUT=1
+# NEW_STATE and NEW_ID hold the latest review; TIMEOUT=1 if no new review arrived
 ```
 
 ---
@@ -65,6 +73,7 @@ with `run_in_background: true` using the following prompt (substitute real value
 `{REPO}` and `{PR}`):
 
 ---
+
 Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat up to 5 rounds:
 
 **Each round:**
@@ -76,6 +85,7 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
 2. If STATE is `APPROVED`: stop. Report "CodeRabbit approved after N round(s). ✓"
 
 3. Extract the AI prompt block from the review body:
+
    ```python
    python3 -c "
    import sys, re
@@ -84,6 +94,7 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
    print(m.group(1).strip() if m else '')
    "
    ```
+
    If empty: stop. Report "No actionable prompt found in latest review."
 
 4. Follow the extracted prompt exactly — verify each finding against the current code,
@@ -91,18 +102,21 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
    `lint-typecheck` subagent for `pnpm exec tsc --noEmit`. If either fails, stop and
    report the errors with full detail.
 
-5. `git add -A && git commit -m "fix: CodeRabbit 리뷰 반영 (Round N)"` then `git push`.
+5. `git add -A && git commit -m "fix: address CodeRabbit review findings (round N)"` then `git push`.
 
 6. Reply to every inline comment from this review:
+
    ```bash
    SHA=$(git rev-parse --short HEAD)
    for ID in $(gh api /repos/{REPO}/pulls/{PR}/reviews/$REVIEW_ID/comments --jq '.[].id'); do
-     gh api /repos/{REPO}/pulls/comments/$ID/replies -X POST -f body="${SHA}에서 반영했습니다."
+     gh api /repos/{REPO}/pulls/comments/$ID/replies -X POST -f body="Applied in ${SHA}."
    done
    ```
 
 7. Poll for a new CodeRabbit review (every 30s, up to 3 minutes):
+
    ```bash
+   TIMEOUT=0
    for i in $(seq 1 6); do
      sleep 30
      RESULT=$(gh api /repos/{REPO}/pulls/{PR}/reviews \
@@ -110,23 +124,29 @@ Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat 
      NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'])")
      [ "$NEW_ID" != "$REVIEW_ID" ] && break
    done
+   [ "$NEW_ID" = "$REVIEW_ID" ] && TIMEOUT=1
    ```
-   If timeout (no new review): stop. Report "No new review after 3 minutes."
+
+   If TIMEOUT=1: stop. Report "No new review after 3 minutes."
 
 8. Update REVIEW_ID and STATE from the new review and continue to next round.
 
 **Final report format:**
-```
+
+```text
 Round 1: N findings → abc1234
 Round 2: M findings → def5678
 Round 3: CodeRabbit APPROVED ✓
 ```
-or if max rounds hit:
-```
+
+Or if max rounds hit:
+
+```text
 Stopped after 5 rounds — not yet approved.
 Remaining findings: [one-line summary of last prompt]
 Last commit: {sha}
 ```
+
 ---
 
 After spawning the agent, report to the user:
@@ -138,24 +158,28 @@ After spawning the agent, report to the user:
 
 Run the loop inline. The coordinator does the fix work each round.
 
+Initialize `ROUND=0` before starting.
+
 **Round start:**
-1. Fetch the latest CodeRabbit review. Save REVIEW_ID, STATE, and body.
-2. If STATE is `APPROVED`: stop — "CodeRabbit has already approved this PR."
-3. Extract the AI prompt block. If empty: stop — "No actionable prompt found in the latest review."
-4. Print the round header and the full extracted prompt so the coordinator can read it.
+1. Increment ROUND. If ROUND > 5: stop — "Maximum 5 rounds reached — stop."
+2. Fetch the latest CodeRabbit review. Save REVIEW_ID, STATE, and body.
+3. If STATE is `APPROVED`: stop — "CodeRabbit has already approved this PR."
+4. Extract the AI prompt block. If empty: stop — "No actionable prompt found in the latest review."
+5. Print the round header and the full extracted prompt so the coordinator can read it.
 
 **Fix:**
-5. Follow the extracted prompt exactly — verify each finding against current code, fix only
+6. Follow the extracted prompt exactly — verify each finding against current code, fix only
    what is needed. Delegate tests to `test-runner` and type checking to `lint-typecheck`.
    Stop and report if either fails.
-6. `git add -A && git commit -m "fix: CodeRabbit 리뷰 반영 (Round N)"` then `git push`.
+7. `git add -A && git commit -m "fix: address CodeRabbit review findings (round $ROUND)"` then `git push`.
 
 **Reply:**
-7. Reply to every inline comment from REVIEW_ID using the reply helper above.
+8. Reply to every inline comment from REVIEW_ID using the reply helper above.
 
 **Poll:**
-8. Poll for a new review using the poll helper above (PREV_ID = REVIEW_ID).
-9. On timeout: stop — "No new review after 3 minutes. Run `/address-review` again once CodeRabbit responds."
-10. If new STATE is `APPROVED`: stop — "CodeRabbit approved after N round(s). ✓"
-11. If new STATE is `CHANGES_REQUESTED`: print the new findings and ask:
-    **"Continue with Round N+1? [Y/n]"** — loop back to Round start if confirmed, otherwise stop.
+9. Poll for a new review using the poll helper above (PREV_ID = REVIEW_ID).
+10. If TIMEOUT=1: stop — "No new review after 3 minutes. Run `/address-review` again once CodeRabbit responds."
+11. If new STATE is `APPROVED`: stop — "CodeRabbit approved after $ROUND round(s). ✓"
+12. If new STATE is `CHANGES_REQUESTED` and ROUND < 5: print the new findings and ask
+    **"Continue with Round $((ROUND+1))? [Y/n]"** — loop back to Round start if confirmed, otherwise stop.
+13. If new STATE is `CHANGES_REQUESTED` and ROUND = 5: stop — "Maximum 5 rounds reached — stop."

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -68,7 +68,7 @@ done
 
 ## If `--background` is in $ARGUMENTS
 
-Resolve REPO and PR using the setup commands above, then spawn a `general-purpose` agent
+Resolve REPO and PR using the setup commands above, then spawn a background agent
 with `run_in_background: true` using the following prompt (substitute real values for
 `{REPO}` and `{PR}`):
 

--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: address-review
+description: Extract CodeRabbit's consolidated AI prompt from the latest PR review and fix all findings. Loops each round until APPROVED. Pass --background to run autonomously in a background agent (up to 5 rounds).
+argument-hint: '[--background]'
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Agent
+---
+
+Fix all outstanding CodeRabbit review findings on the current PR.
+
+## Setup (run once)
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+PR=$(gh pr view --json number --jq .number)
+```
+
+## Shared helpers
+
+**Fetch latest CodeRabbit review** (returns JSON with `id`, `state`, `body`):
+```bash
+gh api /repos/$REPO/pulls/$PR/reviews \
+  --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state, body: .body}'
+```
+
+**Extract the AI prompt block** from a review body (pipe body text into this):
+```bash
+python3 -c "
+import sys, re
+body = sys.stdin.read()
+m = re.search(r'Prompt for all review comments.*?\x60\x60\x60\n(.*?)\x60\x60\x60', body, re.DOTALL)
+print(m.group(1).strip() if m else '')
+"
+```
+
+**Reply to all inline comments from a review** after committing:
+```bash
+SHA=$(git rev-parse --short HEAD)
+REVIEW_ID=<id from fetch step>
+for ID in $(gh api /repos/$REPO/pulls/$PR/reviews/$REVIEW_ID/comments --jq '.[].id'); do
+  gh api /repos/$REPO/pulls/comments/$ID/replies -X POST \
+    -f body="${SHA}에서 반영했습니다."
+done
+```
+
+**Poll for a new CodeRabbit review** (call after push; pass previous review ID):
+```bash
+PREV_ID=<id before push>
+for i in $(seq 1 6); do
+  sleep 30
+  RESULT=$(gh api /repos/$REPO/pulls/$PR/reviews \
+    --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state}')
+  NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'])")
+  NEW_STATE=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['state'])")
+  [ "$NEW_ID" != "$PREV_ID" ] && break
+done
+# NEW_STATE and NEW_ID are now set to the latest review
+```
+
+---
+
+## If `--background` is in $ARGUMENTS
+
+Resolve REPO and PR using the setup commands above, then spawn a `general-purpose` agent
+with `run_in_background: true` using the following prompt (substitute real values for
+`{REPO}` and `{PR}`):
+
+---
+Run an autonomous CodeRabbit review-fix loop on PR #{PR} in repo {REPO}. Repeat up to 5 rounds:
+
+**Each round:**
+
+1. Fetch the latest CodeRabbit review:
+   `gh api /repos/{REPO}/pulls/{PR}/reviews --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id: .id, state: .state, body: .body}'`
+   Save `id` as REVIEW_ID and `state` as STATE.
+
+2. If STATE is `APPROVED`: stop. Report "CodeRabbit approved after N round(s). ✓"
+
+3. Extract the AI prompt block from the review body:
+   ```python
+   python3 -c "
+   import sys, re
+   body = sys.stdin.read()
+   m = re.search(r'Prompt for all review comments.*?\x60\x60\x60\n(.*?)\x60\x60\x60', body, re.DOTALL)
+   print(m.group(1).strip() if m else '')
+   "
+   ```
+   If empty: stop. Report "No actionable prompt found in latest review."
+
+4. Follow the extracted prompt exactly — verify each finding against the current code,
+   fix only what is needed. Use `test-runner` subagent for `pnpm test` and
+   `lint-typecheck` subagent for `pnpm exec tsc --noEmit`. If either fails, stop and
+   report the errors with full detail.
+
+5. `git add -A && git commit -m "fix: CodeRabbit 리뷰 반영 (Round N)"` then `git push`.
+
+6. Reply to every inline comment from this review:
+   ```bash
+   SHA=$(git rev-parse --short HEAD)
+   for ID in $(gh api /repos/{REPO}/pulls/{PR}/reviews/$REVIEW_ID/comments --jq '.[].id'); do
+     gh api /repos/{REPO}/pulls/comments/$ID/replies -X POST -f body="${SHA}에서 반영했습니다."
+   done
+   ```
+
+7. Poll for a new CodeRabbit review (every 30s, up to 3 minutes):
+   ```bash
+   for i in $(seq 1 6); do
+     sleep 30
+     RESULT=$(gh api /repos/{REPO}/pulls/{PR}/reviews \
+       --jq '[.[] | select(.user.login | contains("coderabbitai"))] | last | {id:.id,state:.state}')
+     NEW_ID=$(echo "$RESULT" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['id'])")
+     [ "$NEW_ID" != "$REVIEW_ID" ] && break
+   done
+   ```
+   If timeout (no new review): stop. Report "No new review after 3 minutes."
+
+8. Update REVIEW_ID and STATE from the new review and continue to next round.
+
+**Final report format:**
+```
+Round 1: N findings → abc1234
+Round 2: M findings → def5678
+Round 3: CodeRabbit APPROVED ✓
+```
+or if max rounds hit:
+```
+Stopped after 5 rounds — not yet approved.
+Remaining findings: [one-line summary of last prompt]
+Last commit: {sha}
+```
+---
+
+After spawning the agent, report to the user:
+> Background agent launched for PR #$PR. You'll be notified when it completes.
+
+---
+
+## Default (foreground) mode
+
+Run the loop inline. The coordinator does the fix work each round.
+
+**Round start:**
+1. Fetch the latest CodeRabbit review. Save REVIEW_ID, STATE, and body.
+2. If STATE is `APPROVED`: stop — "CodeRabbit has already approved this PR."
+3. Extract the AI prompt block. If empty: stop — "No actionable prompt found in the latest review."
+4. Print the round header and the full extracted prompt so the coordinator can read it.
+
+**Fix:**
+5. Follow the extracted prompt exactly — verify each finding against current code, fix only
+   what is needed. Delegate tests to `test-runner` and type checking to `lint-typecheck`.
+   Stop and report if either fails.
+6. `git add -A && git commit -m "fix: CodeRabbit 리뷰 반영 (Round N)"` then `git push`.
+
+**Reply:**
+7. Reply to every inline comment from REVIEW_ID using the reply helper above.
+
+**Poll:**
+8. Poll for a new review using the poll helper above (PREV_ID = REVIEW_ID).
+9. On timeout: stop — "No new review after 3 minutes. Run `/address-review` again once CodeRabbit responds."
+10. If new STATE is `APPROVED`: stop — "CodeRabbit approved after N round(s). ✓"
+11. If new STATE is `CHANGES_REQUESTED`: print the new findings and ask:
+    **"Continue with Round N+1? [Y/n]"** — loop back to Round start if confirmed, otherwise stop.


### PR DESCRIPTION
## 🔥 PR 제목

feat(skill): address-review — CodeRabbit 리뷰 자동 처리 스킬

## ✨ 작업 내용

CodeRabbit PR 리뷰에서 \"🤖 Prompt for all review comments with AI agents\" 블록을 자동으로 추출하여 수정·테스트·커밋·푸시·댓글 답변까지 처리하는 `/address-review` 스킬을 추가합니다.

- **포그라운드 모드** (기본): 라운드별 수정 후 다음 라운드 전 사용자 확인 프롬프트
- **백그라운드 모드** (`--background`): `run_in_background: true` 에이전트로 최대 5라운드 자율 실행, 완료 시 알림
- 각 인라인 코멘트에 수정 커밋 SHA로 자동 답변
- 매 푸시 후 새 CodeRabbit 리뷰를 30초 간격으로 최대 3분 폴링
- APPROVED 도달 또는 최대 라운드(5) 초과 시 종료

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

PR #19 등 CodeRabbit CHANGES_REQUESTED 리뷰가 있는 PR에서:
```
/address-review            # 포그라운드
/address-review --background  # 백그라운드
```

## 🙏 리뷰어에게 한마디

백그라운드 에이전트 프롬프트가 self-contained여야 해서 일부 로직이 중복됩니다. 추후 공통 헬퍼로 분리할 수 있지만 지금은 명확성을 우선했습니다.

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automated skill to iteratively address PR review comments: fetches the latest review, extracts a consolidated prompt, applies fixes, runs tests and type checks, commits/pushes changes, and replies to inline comments.
  * Runs up to five rounds, stopping on approval or other termination conditions; supports interactive confirmation between rounds.
  * Optional background mode to run the multi-round loop unattended and report progress/completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->