### PR TITLE
안전한 기본값의 Helm 차트 스캐폴드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,16 @@ jobs:
 
       - name: 테스트 및 커버리지
         run: pnpm test --coverage
+
+  helm-chart:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Helm 설정
+        uses: azure/setup-helm@v4
+
+      - name: Helm 차트 검증
+        run: sh scripts/validate-vridge-chart.sh

--- a/deploy/helm/vridge/Chart.yaml
+++ b/deploy/helm/vridge/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: vridge
+description: vridge 웹 애플리케이션용 Helm 차트
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/vridge/templates/_helpers.tpl
+++ b/deploy/helm/vridge/templates/_helpers.tpl
@@ -6,7 +6,12 @@
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name (include "vridge.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- $name := include "vridge.name" . -}}
+{{- if eq .Release.Name $name -}}
+{{- $name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -25,4 +30,19 @@ helm.sh/chart: {{ include "vridge.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: web
+{{- end -}}
+
+{{- define "vridge.probe" -}}
+{{- $probeName := .probeName -}}
+{{- $probeValues := .probeValues -}}
+{{- if $probeValues.enabled }}
+{{ $probeName }}:
+  httpGet:
+    path: {{ $probeValues.path }}
+    port: http
+  initialDelaySeconds: {{ $probeValues.initialDelaySeconds }}
+  periodSeconds: {{ $probeValues.periodSeconds }}
+  timeoutSeconds: {{ $probeValues.timeoutSeconds }}
+  failureThreshold: {{ $probeValues.failureThreshold }}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/vridge/templates/_helpers.tpl
+++ b/deploy/helm/vridge/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "vridge.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vridge.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "vridge.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vridge.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vridge.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vridge.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "vridge.labels" -}}
+helm.sh/chart: {{ include "vridge.chart" . }}
+{{ include "vridge.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: web
+{{- end -}}

--- a/deploy/helm/vridge/templates/deployment.yaml
+++ b/deploy/helm/vridge/templates/deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vridge.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vridge.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vridge.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vridge.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "vridge.name" . }}
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/vridge/templates/deployment.yaml
+++ b/deploy/helm/vridge/templates/deployment.yaml
@@ -38,36 +38,9 @@ spec:
               protocol: TCP
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.probes.startup.enabled }}
-          startupProbe:
-            httpGet:
-              path: {{ .Values.probes.startup.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
-            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
-            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
-          {{- end }}
-          {{- if .Values.probes.liveness.enabled }}
-          livenessProbe:
-            httpGet:
-              path: {{ .Values.probes.liveness.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-          {{- end }}
-          {{- if .Values.probes.readiness.enabled }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.probes.readiness.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
-            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
-            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
-          {{- end }}
+          {{- include "vridge.probe" (dict "probeName" "startupProbe" "probeValues" .Values.probes.startup) | nindent 10 }}
+          {{- include "vridge.probe" (dict "probeName" "livenessProbe" "probeValues" .Values.probes.liveness) | nindent 10 }}
+          {{- include "vridge.probe" (dict "probeName" "readinessProbe" "probeValues" .Values.probes.readiness) | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/deploy/helm/vridge/templates/ingress.yaml
+++ b/deploy/helm/vridge/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "vridge.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vridge.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "vridge.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/vridge/templates/ingress.yaml
+++ b/deploy/helm/vridge/templates/ingress.yaml
@@ -14,7 +14,7 @@ spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}
+    - host: {{ .host | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/deploy/helm/vridge/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/vridge/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "vridge.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vridge.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vridge.selectorLabels" . | nindent 6 }}
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/vridge/templates/service.yaml
+++ b/deploy/helm/vridge/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vridge.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vridge.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "vridge.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP

--- a/deploy/helm/vridge/values.yaml
+++ b/deploy/helm/vridge/values.yaml
@@ -1,0 +1,80 @@
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cgm-16/vridge
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations: {}
+  hosts:
+    - host: vridge.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+pdb:
+  enabled: true
+  minAvailable: null
+  maxUnavailable: 1
+
+probes:
+  startup:
+    enabled: true
+    path: /readyz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 10
+    periodSeconds: 20
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /readyz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/helm/vridge/values.yaml
+++ b/deploy/helm/vridge/values.yaml
@@ -19,6 +19,7 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - ALL

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -14,6 +14,7 @@
 ```text
 vridge/
 ├── app/
+├── deploy/
 ├── .storybook/
 ├── backend/
 ├── frontend/
@@ -21,6 +22,7 @@ vridge/
 ├── __tests__/
 ├── docs/
 ├── public/
+├── scripts/
 ├── proxy.ts
 └── 설정 파일들
 ```
@@ -28,6 +30,8 @@ vridge/
 - `public/icons/`에 dialcode picker용 국기 아이콘(`flag-vn.svg`, `flag-kr.svg`)이 추가되었습니다.
 - `public/icons/share.svg` 아이콘은 `/jobs/[id]` 상세 공유 CTA에서 사용됩니다.
 - 인증/디자인 정렬용 공통 컴포넌트로 `frontend/components/ui/login-field.tsx`, `frontend/components/ui/social-ls.tsx`가 추가되었습니다.
+- `deploy/helm/vridge/`는 k3s 배포용 Helm 차트 스캐폴드를 포함합니다.
+- `scripts/validate-vridge-chart.sh`는 Helm 차트 lint 및 렌더링 검증 진입점입니다.
 
 ## Next.js 라우트 구조 (`app/`)
 

--- a/scripts/validate-vridge-chart.sh
+++ b/scripts/validate-vridge-chart.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CHART_DIR="$ROOT_DIR/deploy/helm/vridge"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm 명령을 찾을 수 없습니다. Helm을 설치한 뒤 다시 실행하세요." >&2
+  exit 1
+fi
+
+if grep -R "\.Values\.namespace" "$CHART_DIR/templates" >/dev/null 2>&1; then
+  echo "차트 템플릿에서 .Values.namespace를 사용하면 안 됩니다." >&2
+  exit 1
+fi
+
+helm lint "$CHART_DIR"
+
+rendered_file=$(mktemp)
+trap 'rm -f "$rendered_file"' EXIT
+
+helm template vridge-test "$CHART_DIR" --namespace vridge > "$rendered_file"
+
+assert_doc_contains() {
+  kind=$1
+  pattern=$2
+  message=$3
+
+  if ! awk -v kind="$kind" -v pattern="$pattern" '
+    $0 == "kind: " kind { in_doc = 1 }
+    in_doc && $0 ~ pattern { found = 1 }
+    in_doc && $0 == "---" { exit }
+    END { exit found ? 0 : 1 }
+  ' "$rendered_file"; then
+    echo "$message" >&2
+    exit 1
+  fi
+}
+
+assert_doc_contains "Service" "^  type: ClusterIP$" "Service가 기본값 ClusterIP를 렌더링하지 않았습니다."
+assert_doc_contains "Ingress" "^  ingressClassName: traefik$" "Ingress가 traefik ingress class를 렌더링하지 않았습니다."
+assert_doc_contains "Service" "^    app\\.kubernetes\\.io/name: vridge$" "Service selector에 표준 name 레이블이 없습니다."
+assert_doc_contains "Service" "^    app\\.kubernetes\\.io/instance: vridge-test$" "Service selector에 release instance 레이블이 없습니다."
+assert_doc_contains "Deployment" "^      app\\.kubernetes\\.io/name: vridge$" "Deployment selector에 표준 name 레이블이 없습니다."
+assert_doc_contains "Deployment" "^      app\\.kubernetes\\.io/instance: vridge-test$" "Deployment selector에 release instance 레이블이 없습니다."
+assert_doc_contains "Deployment" "^  namespace: vridge$" "Deployment가 release namespace를 렌더링하지 않았습니다."

--- a/scripts/validate-vridge-chart.sh
+++ b/scripts/validate-vridge-chart.sh
@@ -17,30 +17,36 @@ fi
 helm lint "$CHART_DIR"
 
 rendered_file=$(mktemp)
-trap 'rm -f "$rendered_file"' EXIT
+duplicate_name_rendered_file=$(mktemp)
+trap 'rm -f "$rendered_file" "$duplicate_name_rendered_file"' EXIT
 
 helm template vridge-test "$CHART_DIR" --namespace vridge > "$rendered_file"
+helm template vridge "$CHART_DIR" --namespace vridge > "$duplicate_name_rendered_file"
 
 assert_doc_contains() {
-  kind=$1
-  pattern=$2
-  message=$3
+  rendered_path=$1
+  kind=$2
+  pattern=$3
+  message=$4
 
   if ! awk -v kind="$kind" -v pattern="$pattern" '
     $0 == "kind: " kind { in_doc = 1 }
     in_doc && $0 ~ pattern { found = 1 }
     in_doc && $0 == "---" { exit }
     END { exit found ? 0 : 1 }
-  ' "$rendered_file"; then
+  ' "$rendered_path"; then
     echo "$message" >&2
     exit 1
   fi
 }
 
-assert_doc_contains "Service" "^  type: ClusterIP$" "Service가 기본값 ClusterIP를 렌더링하지 않았습니다."
-assert_doc_contains "Ingress" "^  ingressClassName: traefik$" "Ingress가 traefik ingress class를 렌더링하지 않았습니다."
-assert_doc_contains "Service" "^    app\\.kubernetes\\.io/name: vridge$" "Service selector에 표준 name 레이블이 없습니다."
-assert_doc_contains "Service" "^    app\\.kubernetes\\.io/instance: vridge-test$" "Service selector에 release instance 레이블이 없습니다."
-assert_doc_contains "Deployment" "^      app\\.kubernetes\\.io/name: vridge$" "Deployment selector에 표준 name 레이블이 없습니다."
-assert_doc_contains "Deployment" "^      app\\.kubernetes\\.io/instance: vridge-test$" "Deployment selector에 release instance 레이블이 없습니다."
-assert_doc_contains "Deployment" "^  namespace: vridge$" "Deployment가 release namespace를 렌더링하지 않았습니다."
+assert_doc_contains "$rendered_file" "Service" "^  type: ClusterIP$" "Service가 기본값 ClusterIP를 렌더링하지 않았습니다."
+assert_doc_contains "$rendered_file" "Ingress" "^  ingressClassName: traefik$" "Ingress가 traefik ingress class를 렌더링하지 않았습니다."
+assert_doc_contains "$rendered_file" "Ingress" '^    - host: "vridge\\.example\\.com"$' "Ingress host가 YAML 안전한 따옴표로 렌더링되지 않았습니다."
+assert_doc_contains "$rendered_file" "Service" "^    app\\.kubernetes\\.io/name: vridge$" "Service selector에 표준 name 레이블이 없습니다."
+assert_doc_contains "$rendered_file" "Service" "^    app\\.kubernetes\\.io/instance: vridge-test$" "Service selector에 release instance 레이블이 없습니다."
+assert_doc_contains "$rendered_file" "Deployment" "^      app\\.kubernetes\\.io/name: vridge$" "Deployment selector에 표준 name 레이블이 없습니다."
+assert_doc_contains "$rendered_file" "Deployment" "^      app\\.kubernetes\\.io/instance: vridge-test$" "Deployment selector에 release instance 레이블이 없습니다."
+assert_doc_contains "$rendered_file" "Deployment" "^  namespace: vridge$" "Deployment가 release namespace를 렌더링하지 않았습니다."
+assert_doc_contains "$rendered_file" "Deployment" "^            readOnlyRootFilesystem: true$" "Deployment 컨테이너 보안 컨텍스트에 readOnlyRootFilesystem이 없습니다."
+assert_doc_contains "$duplicate_name_rendered_file" "Deployment" "^  name: vridge$" "릴리스 이름과 차트 이름이 같을 때 fullname이 중복 렌더링됩니다."


### PR DESCRIPTION
## 🔥 PR 제목

> feat + 안전한 기본값의 Helm 차트 스캐폴드

## ✨ 작업 내용

- `deploy/helm/vridge`에 Deployment, Service, Ingress, PodDisruptionBudget, `values.yaml`, 헬퍼 템플릿을 추가했습니다.
- `.Release.Namespace`, 표준 `app.kubernetes.io/*` 레이블, `service.type`, 프로브/리소스/보안 컨텍스트 값을 차트에 반영했습니다.
- `scripts/validate-vridge-chart.sh`와 CI Helm 검증 job을 추가하고, `docs/folder-structure.md`를 현재 구조에 맞게 갱신했습니다.
- 관련 이슈: #6

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `pnpm test`
- `pnpm exec tsc --noEmit`
- `tmpdir=$(mktemp -d /tmp/helm-t05.XXXXXX) && curl -fsSL https://get.helm.sh/helm-v3.15.4-darwin-arm64.tar.gz -o "$tmpdir/helm.tgz" && tar -xzf "$tmpdir/helm.tgz" -C "$tmpdir" && PATH="$tmpdir/darwin-arm64:$PATH" sh scripts/validate-vridge-chart.sh`

## 📸 스크린샷 / 시연 (선택)

> N/A - Helm 차트 스캐폴드 작업입니다.

## 🙏 리뷰어에게 한마디

> `pnpm test`는 통과했지만 기존 `__tests__/lib/infrastructure/auth.test.ts`가 실패 경로 검증 중 `console.error`를 출력합니다. 이번 T05 범위 밖이라 수정하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart to deploy the application with configurable service, ingress, probes, resource limits, and pod disruption budget.

* **Chores**
  * Added CI job to validate the Helm chart and integrated an automated chart validation script into the pipeline.

* **Documentation**
  * Updated docs to describe the new deployment folder and chart validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->