### PR TITLE
feat(task): 프로덕션 컨테이너 빌드 구성 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.next
+.worktrees
+coverage
+docs
+node_modules
+.env
+.env.*
+.codex-memory-*.md
+npm-debug.log*
+pnpm-debug.log*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: 프로젝트 빌드
         run: pnpm build
 
+      - name: 컨테이너 이미지 빌드
+        run: |
+          docker build \
+            --build-arg NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL}" \
+            --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID="${NEXT_PUBLIC_GA_MEASUREMENT_ID}" \
+            --build-arg NEXT_PUBLIC_PRIVACY_POLICY_URL="${NEXT_PUBLIC_PRIVACY_POLICY_URL}" \
+            -t vridge:ci .
+
       - name: 테스트 및 커버리지
         run: pnpm test --coverage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM node:22-bookworm-slim AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable
+
+FROM base AS deps
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml prisma.config.ts ./
+COPY backend/prisma ./backend/prisma
+
+RUN pnpm install --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_APP_URL
+ARG NEXT_PUBLIC_GA_MEASUREMENT_ID
+ARG NEXT_PUBLIC_PRIVACY_POLICY_URL
+
+ENV NEXT_PUBLIC_APP_URL="${NEXT_PUBLIC_APP_URL}"
+ENV NEXT_PUBLIC_GA_MEASUREMENT_ID="${NEXT_PUBLIC_GA_MEASUREMENT_ID}"
+ENV NEXT_PUBLIC_PRIVACY_POLICY_URL="${NEXT_PUBLIC_PRIVACY_POLICY_URL}"
+
+RUN pnpm build
+
+FROM node:22-bookworm-slim AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+RUN groupadd --system --gid 1001 nodejs \
+  && useradd --system --uid 1001 --gid nodejs nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ pnpm dev
 
 브라우저에서 `http://localhost:3000`을 열면 됩니다.
 
+## 프로덕션 컨테이너 빌드
+
+프로덕션 이미지는 공개 빌드 변수만 `docker build` 시점에 받습니다.
+런타임 시크릿(`DATABASE_URL`, `DIRECT_URL`, `BETTER_AUTH_SECRET`)은 컨테이너 실행 시 주입해야 합니다.
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_APP_URL=http://localhost:3000 \
+  --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=G-LOCALTEST \
+  --build-arg NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
+  -t vridge:local .
+```
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e DATABASE_URL=postgresql://postgres:postgres@host.docker.internal:54329/vridge_test \
+  -e DIRECT_URL=postgresql://postgres:postgres@host.docker.internal:54329/vridge_test \
+  -e BETTER_AUTH_SECRET=dev-secret-dev-secret-dev-secret \
+  -e BETTER_AUTH_URL=http://localhost:3000 \
+  -e NEXT_PUBLIC_APP_URL=http://localhost:3000 \
+  -e NEXT_PUBLIC_GA_MEASUREMENT_ID=G-LOCALTEST \
+  -e NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
+  vridge:local
+```
+
 ## 스크립트
 
 | Script                   | 설명                           |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ pnpm dev
 
 프로덕션 이미지는 공개 빌드 변수만 `docker build` 시점에 받습니다.
 런타임 시크릿(`DATABASE_URL`, `DIRECT_URL`, `BETTER_AUTH_SECRET`)은 컨테이너 실행 시 주입해야 합니다.
+`NEXT_PUBLIC_*` 값은 클라이언트 번들에 빌드 타임에 고정되므로 `docker run -e`로는 바꿀 수 없습니다.
 
 ```bash
 docker build \
@@ -83,9 +84,6 @@ docker run --rm -p 3000:3000 \
   -e DIRECT_URL=postgresql://postgres:postgres@host.docker.internal:54329/vridge_test \
   -e BETTER_AUTH_SECRET=dev-secret-dev-secret-dev-secret \
   -e BETTER_AUTH_URL=http://localhost:3000 \
-  -e NEXT_PUBLIC_APP_URL=http://localhost:3000 \
-  -e NEXT_PUBLIC_GA_MEASUREMENT_ID=G-LOCALTEST \
-  -e NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
   vridge:local
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ pnpm dev
 ## 프로덕션 컨테이너 빌드
 
 프로덕션 이미지는 공개 빌드 변수만 `docker build` 시점에 받습니다.
-런타임 시크릿(`DATABASE_URL`, `DIRECT_URL`, `BETTER_AUTH_SECRET`)은 컨테이너 실행 시 주입해야 합니다.
+런타임 변수(`DATABASE_URL`, `DIRECT_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`)는 컨테이너 실행 시 주입해야 합니다.
 `NEXT_PUBLIC_*` 값은 클라이언트 번들에 빌드 타임에 고정되므로 `docker run -e`로는 바꿀 수 없습니다.
 
 ```bash

--- a/__tests__/app/api/auth-route.test.ts
+++ b/__tests__/app/api/auth-route.test.ts
@@ -27,7 +27,15 @@ describe('auth route', () => {
     mockToNextJsHandler.mockClear();
   });
 
-  it('모듈 로드 시 Next.js 핸들러를 1회만 생성한다', async () => {
+  it('모듈 import 시 Auth 핸들러를 생성하지 않는다', async () => {
+    const route = await import('@/app/api/auth/[...all]/route');
+
+    expect(route).toBeDefined();
+    expect(mockGetAuth).not.toHaveBeenCalled();
+    expect(mockToNextJsHandler).not.toHaveBeenCalled();
+  });
+
+  it('첫 요청 시 핸들러를 생성하고 이후 요청에서는 재사용한다', async () => {
     const route = await import('@/app/api/auth/[...all]/route');
     const getRequest = new Request('http://localhost/api/auth/session');
     const postRequest = new Request('http://localhost/api/auth/sign-in', {

--- a/__tests__/app/api/auth-route.test.ts
+++ b/__tests__/app/api/auth-route.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetAuth = jest.fn(() => ({ api: {} }));
+const mockGet = jest.fn(async () => new Response(null, { status: 204 }));
+const mockPost = jest.fn(async () => new Response(null, { status: 204 }));
+const mockToNextJsHandler = jest.fn(() => ({
+  GET: mockGet,
+  POST: mockPost,
+}));
+
+jest.mock('@/backend/infrastructure/auth', () => ({
+  getAuth: mockGetAuth,
+}));
+
+jest.mock('better-auth/next-js', () => ({
+  toNextJsHandler: mockToNextJsHandler,
+}));
+
+describe('auth route', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockGetAuth.mockClear();
+    mockGet.mockClear();
+    mockPost.mockClear();
+    mockToNextJsHandler.mockClear();
+  });
+
+  it('모듈 로드 시 Next.js 핸들러를 1회만 생성한다', async () => {
+    const route = await import('@/app/api/auth/[...all]/route');
+    const getRequest = new Request('http://localhost/api/auth/session');
+    const postRequest = new Request('http://localhost/api/auth/sign-in', {
+      method: 'POST',
+    });
+
+    await route.GET(getRequest);
+    await route.POST(postRequest);
+
+    expect(mockGetAuth).toHaveBeenCalledTimes(1);
+    expect(mockToNextJsHandler).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith(getRequest);
+    expect(mockPost).toHaveBeenCalledWith(postRequest);
+  });
+});

--- a/__tests__/app/job-detail-page.test.tsx
+++ b/__tests__/app/job-detail-page.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import JobDetailPage from '@/app/jobs/[id]/page';
 import { headers } from 'next/headers';
-import { auth } from '@/backend/infrastructure/auth';
+import { getAuth } from '@/backend/infrastructure/auth';
 import { getJobDescriptionById } from '@/backend/actions/jd-queries';
 import { getMyApplications } from '@/backend/actions/applications';
 import { renderWithI18n } from '@/__tests__/test-utils/render-with-i18n';
@@ -17,11 +17,14 @@ jest.mock('react-markdown', () => ({
 }));
 
 jest.mock('@/backend/infrastructure/auth', () => ({
-  auth: {
-    api: {
-      getSession: jest.fn(),
-    },
-  },
+  getAuth: (() => {
+    const auth = {
+      api: {
+        getSession: jest.fn(),
+      },
+    };
+    return jest.fn(() => auth);
+  })(),
 }));
 
 jest.mock('@/backend/actions/jd-queries', () => ({
@@ -95,7 +98,7 @@ jest.mock('@/shared/i18n/server', () => {
 });
 
 const mockHeaders = headers as unknown as jest.Mock;
-const mockGetSession = auth.api.getSession as unknown as jest.Mock;
+const mockGetSession = getAuth().api.getSession as unknown as jest.Mock;
 const mockGetJobDescriptionById = getJobDescriptionById as unknown as jest.Mock;
 const mockGetMyApplications = getMyApplications as unknown as jest.Mock;
 const JOB_MARKDOWN_FIXTURE = [

--- a/__tests__/lib/backend/config/env.test.ts
+++ b/__tests__/lib/backend/config/env.test.ts
@@ -112,6 +112,9 @@ describe('env 설정', () => {
     } catch (e) {
       errorMessage = (e as Error).message;
     }
+    expect(errorMessage).toContain(
+      '필수 환경 변수가 없거나 형식이 올바르지 않습니다'
+    );
     expect(errorMessage).toContain('DATABASE_URL');
     expect(errorMessage).toContain('BETTER_AUTH_SECRET');
   });

--- a/__tests__/lib/backend/config/env.test.ts
+++ b/__tests__/lib/backend/config/env.test.ts
@@ -1,7 +1,7 @@
 // 중요: jest.mock 호출은 모든 import보다 먼저 와야 합니다
 // 이 파일에는 모의(mock)가 필요 없습니다
 
-import type { Env } from '@/backend/config/env';
+import type { Env, PublicEnv } from '@/backend/config/env';
 
 const VALID_ENV: Record<string, string> = {
   DATABASE_URL: 'postgresql://localhost/db',
@@ -32,44 +32,66 @@ describe('env 설정', () => {
     Object.assign(process.env, savedEnv);
   });
 
-  it('모든 변수가 있으면 env 객체를 내보낸다', async () => {
+  it('모든 변수가 있으면 getEnv가 전체 env 객체를 반환한다', async () => {
     Object.assign(process.env, VALID_ENV);
-    const { env } = (await import('@/backend/config/env')) as { env: Env };
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
+    const env = getEnv();
     expect(env.DATABASE_URL).toBe(VALID_ENV.DATABASE_URL);
     expect(env.NEXT_PUBLIC_GA_MEASUREMENT_ID).toBe('G-TEST123');
+  });
+
+  it('공개 변수만 있으면 getPublicEnv가 공개 env 객체를 반환한다', async () => {
+    Object.assign(process.env, {
+      NEXT_PUBLIC_APP_URL: VALID_ENV.NEXT_PUBLIC_APP_URL,
+      NEXT_PUBLIC_GA_MEASUREMENT_ID: VALID_ENV.NEXT_PUBLIC_GA_MEASUREMENT_ID,
+      NEXT_PUBLIC_PRIVACY_POLICY_URL: VALID_ENV.NEXT_PUBLIC_PRIVACY_POLICY_URL,
+    });
+    const { getPublicEnv } = (await import('@/backend/config/env')) as {
+      getPublicEnv: () => PublicEnv;
+    };
+    const env = getPublicEnv();
+    expect(env.NEXT_PUBLIC_APP_URL).toBe(VALID_ENV.NEXT_PUBLIC_APP_URL);
   });
 
   it('DATABASE_URL 누락 시 throw한다', async () => {
     Object.assign(process.env, VALID_ENV);
     delete process.env.DATABASE_URL;
-    await expect(import('@/backend/config/env')).rejects.toThrow(
-      /DATABASE_URL/
-    );
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
+    expect(() => getEnv()).toThrow(/DATABASE_URL/);
   });
 
   it('BETTER_AUTH_SECRET 누락 시 throw한다', async () => {
     Object.assign(process.env, VALID_ENV);
     delete process.env.BETTER_AUTH_SECRET;
-    await expect(import('@/backend/config/env')).rejects.toThrow(
-      /BETTER_AUTH_SECRET/
-    );
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
+    expect(() => getEnv()).toThrow(/BETTER_AUTH_SECRET/);
   });
 
   it('NEXT_PUBLIC_APP_URL이 URL 형식이 아니면 throw한다', async () => {
     Object.assign(process.env, VALID_ENV);
     process.env.NEXT_PUBLIC_APP_URL = 'not-a-url';
-    await expect(import('@/backend/config/env')).rejects.toThrow(
-      /NEXT_PUBLIC_APP_URL/
-    );
+    const { getPublicEnv } = (await import('@/backend/config/env')) as {
+      getPublicEnv: () => PublicEnv;
+    };
+    expect(() => getPublicEnv()).toThrow(/NEXT_PUBLIC_APP_URL/);
   });
 
   it('에러 메시지에 시크릿 값이 포함되지 않는다', async () => {
     Object.assign(process.env, VALID_ENV);
     process.env.BETTER_AUTH_SECRET = 'my-super-secret-value';
     delete process.env.DATABASE_URL; // 에러를 강제 발생시키기 위해 삭제
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
     let errorMessage = '';
     try {
-      await import('@/backend/config/env');
+      getEnv();
     } catch (e) {
       errorMessage = (e as Error).message;
     }
@@ -81,9 +103,12 @@ describe('env 설정', () => {
     Object.assign(process.env, VALID_ENV);
     delete process.env.DATABASE_URL;
     delete process.env.BETTER_AUTH_SECRET;
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
     let errorMessage = '';
     try {
-      await import('@/backend/config/env');
+      getEnv();
     } catch (e) {
       errorMessage = (e as Error).message;
     }
@@ -94,16 +119,18 @@ describe('env 설정', () => {
   it('GOOGLE_CLIENT_ID만 있고 GOOGLE_CLIENT_SECRET 없으면 throw한다', async () => {
     Object.assign(process.env, VALID_ENV);
     delete process.env.GOOGLE_CLIENT_SECRET;
-    await expect(import('@/backend/config/env')).rejects.toThrow(
-      /GOOGLE_CLIENT_ID/
-    );
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
+    expect(() => getEnv()).toThrow(/GOOGLE_CLIENT_ID/);
   });
 
   it('FACEBOOK_CLIENT_SECRET만 있고 FACEBOOK_CLIENT_ID 없으면 throw한다', async () => {
     Object.assign(process.env, VALID_ENV);
     delete process.env.FACEBOOK_CLIENT_ID;
-    await expect(import('@/backend/config/env')).rejects.toThrow(
-      /FACEBOOK_CLIENT/
-    );
+    const { getEnv } = (await import('@/backend/config/env')) as {
+      getEnv: () => Env;
+    };
+    expect(() => getEnv()).toThrow(/FACEBOOK_CLIENT/);
   });
 });

--- a/__tests__/lib/backend/infrastructure/lazy-init.test.ts
+++ b/__tests__/lib/backend/infrastructure/lazy-init.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment node
+ */
+import { TextEncoder } from 'node:util';
+
+jest.mock('better-auth', () => ({
+  betterAuth: jest.fn(() => ({ api: { getSession: jest.fn() } })),
+}));
+jest.mock('better-auth/adapters/prisma', () => ({
+  prismaAdapter: jest.fn(() => 'mock-db-adapter'),
+}));
+jest.mock('better-auth/next-js', () => ({
+  nextCookies: jest.fn(() => 'mock-next-cookies-plugin'),
+}));
+
+const PUBLIC_ENV: Record<string, string> = {
+  NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+  NEXT_PUBLIC_GA_MEASUREMENT_ID: 'G-TEST123',
+  NEXT_PUBLIC_PRIVACY_POLICY_URL: 'http://localhost/privacy',
+};
+
+describe('server infrastructure lazy init', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    global.TextEncoder = TextEncoder;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(PUBLIC_ENV)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, savedEnv);
+  });
+
+  it('런타임 시크릿 없이도 db/auth 모듈을 import할 수 있다', async () => {
+    Object.assign(process.env, PUBLIC_ENV);
+
+    await expect(import('@/backend/infrastructure/db')).resolves.toHaveProperty(
+      'getPrisma'
+    );
+    await expect(
+      import('@/backend/infrastructure/auth')
+    ).resolves.toHaveProperty('getAuth');
+  });
+});

--- a/__tests__/lib/infrastructure/auth-utils.test.ts
+++ b/__tests__/lib/infrastructure/auth-utils.test.ts
@@ -1,23 +1,33 @@
 jest.mock('@/backend/infrastructure/auth', () => ({
-  auth: { api: { getSession: jest.fn() } },
+  getAuth: (() => {
+    const auth = {
+      api: { getSession: jest.fn() },
+    };
+    return jest.fn(() => auth);
+  })(),
 }));
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: { appUser: { findUnique: jest.fn() } },
+  getPrisma: (() => {
+    const prisma = {
+      appUser: { findUnique: jest.fn() },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
 jest.mock('next/headers', () => ({
   headers: jest.fn().mockResolvedValue(new Headers()),
 }));
 
-import { auth } from '@/backend/infrastructure/auth';
-import { prisma } from '@/backend/infrastructure/db';
+import { getAuth } from '@/backend/infrastructure/auth';
+import { getPrisma } from '@/backend/infrastructure/db';
 import {
   getCurrentUser,
   requireUser,
   requireRole,
 } from '@/backend/infrastructure/auth-utils';
 
-const mockGetSession = auth.api.getSession as unknown as jest.Mock;
-const mockFindUnique = prisma.appUser.findUnique as unknown as jest.Mock;
+const mockGetSession = getAuth().api.getSession as unknown as jest.Mock;
+const mockFindUnique = getPrisma().appUser.findUnique as unknown as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/__tests__/lib/infrastructure/auth.test.ts
+++ b/__tests__/lib/infrastructure/auth.test.ts
@@ -1,12 +1,17 @@
 jest.mock('@/backend/config/env', () => ({
-  env: {
+  getEnv: jest.fn(() => ({
+    DATABASE_URL: 'postgresql://localhost/test-db',
+    DIRECT_URL: 'postgresql://localhost/test-db',
     BETTER_AUTH_SECRET: 'test-secret',
     BETTER_AUTH_URL: 'http://localhost:3000',
     GOOGLE_CLIENT_ID: 'gid',
     GOOGLE_CLIENT_SECRET: 'gsecret',
     FACEBOOK_CLIENT_ID: 'fid',
     FACEBOOK_CLIENT_SECRET: 'fsecret',
-  },
+    NEXT_PUBLIC_APP_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_GA_MEASUREMENT_ID: 'G-TEST123',
+    NEXT_PUBLIC_PRIVACY_POLICY_URL: 'http://localhost/privacy',
+  })),
 }));
 jest.mock('better-auth', () => ({
   betterAuth: jest.fn((config: unknown) => ({ options: config })),
@@ -19,20 +24,34 @@ jest.mock('better-auth/next-js', () => ({
   toNextJsHandler: jest.fn(),
 }));
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: {
-    $transaction: jest.fn(),
-    user: { delete: jest.fn() },
-  },
+  getPrisma: (() => {
+    const prisma = {
+      $transaction: jest.fn(),
+      user: { delete: jest.fn() },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
 
 import { betterAuth } from 'better-auth';
-import { auth } from '@/backend/infrastructure/auth';
-import { prisma } from '@/backend/infrastructure/db';
+import { getAuth } from '@/backend/infrastructure/auth';
+import { getPrisma } from '@/backend/infrastructure/db';
+
+const auth = getAuth();
+const prisma = getPrisma();
+const mockConsoleError = jest
+  .spyOn(console, 'error')
+  .mockImplementation(() => undefined);
 
 describe('auth', () => {
   beforeEach(() => {
     (prisma.$transaction as jest.Mock).mockReset();
     (prisma.user.delete as jest.Mock).mockReset();
+    mockConsoleError.mockClear();
+  });
+
+  afterAll(() => {
+    mockConsoleError.mockRestore();
   });
 
   it('auth 인스턴스가 정의됨', () => {

--- a/__tests__/lib/use-cases/announcements.test.ts
+++ b/__tests__/lib/use-cases/announcements.test.ts
@@ -4,18 +4,23 @@ import {
   getAnnouncementNeighbors,
 } from '@/backend/use-cases/announcements';
 import { DomainError } from '@/backend/domain/errors';
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: {
-    announcement: {
-      findMany: jest.fn(),
-      count: jest.fn(),
-      findUnique: jest.fn(),
-      findFirst: jest.fn(),
-    },
-  },
+  getPrisma: (() => {
+    const prisma = {
+      announcement: {
+        findMany: jest.fn(),
+        count: jest.fn(),
+        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+      },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
+
+const prisma = getPrisma();
 
 beforeEach(() => jest.clearAllMocks());
 

--- a/__tests__/lib/use-cases/applications.test.ts
+++ b/__tests__/lib/use-cases/applications.test.ts
@@ -6,23 +6,28 @@ import {
   getApplicantStats,
 } from '@/backend/use-cases/applications';
 import { DomainError } from '@/backend/domain/errors';
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: {
-    apply: {
-      create: jest.fn(),
-      findFirst: jest.fn(),
-      findUnique: jest.fn(),
-      findMany: jest.fn(),
-      update: jest.fn(),
-      groupBy: jest.fn(),
-    },
-    jobDescription: {
-      findUnique: jest.fn(),
-    },
-  },
+  getPrisma: (() => {
+    const prisma = {
+      apply: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+        groupBy: jest.fn(),
+      },
+      jobDescription: {
+        findUnique: jest.fn(),
+      },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
+
+const prisma = getPrisma();
 
 beforeEach(() => jest.clearAllMocks());
 

--- a/__tests__/lib/use-cases/catalog.test.ts
+++ b/__tests__/lib/use-cases/catalog.test.ts
@@ -4,15 +4,20 @@ import {
   searchSkills,
   getSkillById,
 } from '@/backend/use-cases/catalog';
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: {
-    jobFamily: { findMany: jest.fn() },
-    job: { findMany: jest.fn() },
-    skill: { findMany: jest.fn(), findUnique: jest.fn() },
-  },
+  getPrisma: (() => {
+    const prisma = {
+      jobFamily: { findMany: jest.fn() },
+      job: { findMany: jest.fn() },
+      skill: { findMany: jest.fn(), findUnique: jest.fn() },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
+
+const prisma = getPrisma();
 
 beforeEach(() => jest.clearAllMocks());
 

--- a/__tests__/lib/use-cases/jd-queries.test.ts
+++ b/__tests__/lib/use-cases/jd-queries.test.ts
@@ -3,17 +3,22 @@ import {
   getJobDescriptionById,
 } from '@/backend/use-cases/jd-queries';
 import { DomainError } from '@/backend/domain/errors';
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: {
-    jobDescription: {
-      findMany: jest.fn(),
-      count: jest.fn(),
-      findUnique: jest.fn(),
-    },
-  },
+  getPrisma: (() => {
+    const prisma = {
+      jobDescription: {
+        findMany: jest.fn(),
+        count: jest.fn(),
+        findUnique: jest.fn(),
+      },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
+
+const prisma = getPrisma();
 
 beforeEach(() => jest.clearAllMocks());
 

--- a/__tests__/lib/use-cases/profile.test.ts
+++ b/__tests__/lib/use-cases/profile.test.ts
@@ -23,56 +23,61 @@ import {
   deleteCertification,
 } from '@/backend/use-cases/profile';
 import { DomainError } from '@/backend/domain/errors';
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 
 jest.mock('@/backend/infrastructure/db', () => ({
-  prisma: {
-    appUser: {
-      findUnique: jest.fn(),
-      findFirst: jest.fn(),
-    },
-    profilesPublic: {
-      update: jest.fn(),
-    },
-    profilesPrivate: {
-      update: jest.fn(),
-    },
-    profileCareer: {
-      findFirst: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-    },
-    profileEducation: {
-      findFirst: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-    },
-    profileLanguage: {
-      findFirst: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-    },
-    profileUrl: {
-      findFirst: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-    },
-    profileSkill: {
-      create: jest.fn(),
-      deleteMany: jest.fn(),
-    },
-    profileCertification: {
-      findFirst: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-    },
-  },
+  getPrisma: (() => {
+    const prisma = {
+      appUser: {
+        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      profilesPublic: {
+        update: jest.fn(),
+      },
+      profilesPrivate: {
+        update: jest.fn(),
+      },
+      profileCareer: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      profileEducation: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      profileLanguage: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      profileUrl: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      profileSkill: {
+        create: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      profileCertification: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    return jest.fn(() => prisma);
+  })(),
 }));
+
+const prisma = getPrisma();
 
 beforeEach(() => jest.clearAllMocks());
 

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -2,14 +2,19 @@
  * @jest-environment node
  */
 jest.mock('@/backend/infrastructure/auth', () => ({
-  auth: { api: { getSession: jest.fn() } },
+  getAuth: (() => {
+    const auth = {
+      api: { getSession: jest.fn() },
+    };
+    return jest.fn(() => auth);
+  })(),
 }));
 
 import { NextRequest } from 'next/server';
 import { proxy } from '@/proxy';
-import { auth } from '@/backend/infrastructure/auth';
+import { getAuth } from '@/backend/infrastructure/auth';
 
-const mockGetSession = auth.api.getSession as unknown as jest.Mock;
+const mockGetSession = getAuth().api.getSession as unknown as jest.Mock;
 
 function makeRequest(path: string) {
   return new NextRequest(new URL(path, 'http://localhost:3000'));

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,4 +1,14 @@
-import { auth } from '@/backend/infrastructure/auth';
+import { getAuth } from '@/backend/infrastructure/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
 
-export const { GET, POST } = toNextJsHandler(auth);
+function getHandler() {
+  return toNextJsHandler(getAuth());
+}
+
+export async function GET(request: Request) {
+  return getHandler().GET(request);
+}
+
+export async function POST(request: Request) {
+  return getHandler().POST(request);
+}

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,14 +1,12 @@
 import { getAuth } from '@/backend/infrastructure/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
 
-function getHandler() {
-  return toNextJsHandler(getAuth());
-}
+const authHandler = toNextJsHandler(getAuth());
 
 export async function GET(request: Request) {
-  return getHandler().GET(request);
+  return authHandler.GET(request);
 }
 
 export async function POST(request: Request) {
-  return getHandler().POST(request);
+  return authHandler.POST(request);
 }

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,12 +1,17 @@
 import { getAuth } from '@/backend/infrastructure/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
 
-const authHandler = toNextJsHandler(getAuth());
+let authHandler: ReturnType<typeof toNextJsHandler> | undefined;
+
+function getHandler() {
+  authHandler ??= toNextJsHandler(getAuth());
+  return authHandler;
+}
 
 export async function GET(request: Request) {
-  return authHandler.GET(request);
+  return getHandler().GET(request);
 }
 
 export async function POST(request: Request) {
-  return authHandler.POST(request);
+  return getHandler().POST(request);
 }

--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { headers } from 'next/headers';
 import ReactMarkdown from 'react-markdown';
-import { auth } from '@/backend/infrastructure/auth';
+import { getAuth } from '@/backend/infrastructure/auth';
 import { getJobDescriptionById } from '@/backend/actions/jd-queries';
 import { getMyApplications } from '@/backend/actions/applications';
 import { PostingTitle } from '@/frontend/entities/job/ui/posting-title';
@@ -22,7 +22,7 @@ export default async function JobDetailPage({
   const { locale, t } = await getServerI18n();
   const { id } = await params;
 
-  const session = await auth.api.getSession({
+  const session = await getAuth().api.getSession({
     headers: await headers(),
   });
 

--- a/backend/actions/profile.ts
+++ b/backend/actions/profile.ts
@@ -7,7 +7,7 @@ import {
   type ReachabilityChecker,
 } from '@/backend/domain/authorization';
 import { requireUser } from '@/backend/infrastructure/auth-utils';
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 import {
   profilePublicSchema,
   profilePrivateSchema,
@@ -324,8 +324,8 @@ export async function getProfileForRecruiter(
   try {
     const user = await requireUser();
     const checker: ReachabilityChecker = (cId) =>
-      prisma.apply
-        .findFirst({ where: { userId: cId } })
+      getPrisma()
+        .apply.findFirst({ where: { userId: cId } })
         .then((r) => r !== null);
     await assertCanViewCandidate(user.role as AppRole, candidateId, checker);
     const data = await getProfileForViewer(candidateId, 'full');

--- a/backend/config/env.ts
+++ b/backend/config/env.ts
@@ -1,8 +1,14 @@
 import 'server-only';
 import { z } from 'zod';
 
-const envSchema = z
-  .object({
+const publicEnvSchema = z.object({
+  NEXT_PUBLIC_APP_URL: z.string().url(),
+  NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().min(1),
+  NEXT_PUBLIC_PRIVACY_POLICY_URL: z.string().url(),
+});
+
+const envSchema = publicEnvSchema
+  .extend({
     DATABASE_URL: z.string().url(),
     DIRECT_URL: z.string().url(),
     BETTER_AUTH_SECRET: z.string().min(1),
@@ -11,9 +17,6 @@ const envSchema = z
     GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
     FACEBOOK_CLIENT_ID: z.string().min(1).optional(),
     FACEBOOK_CLIENT_SECRET: z.string().min(1).optional(),
-    NEXT_PUBLIC_APP_URL: z.string().url(),
-    NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().min(1),
-    NEXT_PUBLIC_PRIVACY_POLICY_URL: z.string().url(),
   })
   .superRefine((data, ctx) => {
     if (!!data.GOOGLE_CLIENT_ID !== !!data.GOOGLE_CLIENT_SECRET) {
@@ -35,14 +38,28 @@ const envSchema = z
   });
 
 export type Env = z.infer<typeof envSchema>;
+export type PublicEnv = z.infer<typeof publicEnvSchema>;
 
-const parsed = envSchema.safeParse(process.env);
-
-if (!parsed.success) {
-  const missing = parsed.error.issues.map((i) => i.path.join('.'));
-  throw new Error(
-    `Missing or invalid environment variables: ${missing.join(', ')}`
-  );
+function parseEnv<T>(schema: z.ZodType<T>): T {
+  const parsed = schema.safeParse(process.env);
+  if (!parsed.success) {
+    const missing = parsed.error.issues.map((i) => i.path.join('.'));
+    throw new Error(
+      `Missing or invalid environment variables: ${missing.join(', ')}`
+    );
+  }
+  return parsed.data;
 }
 
-export const env: Env = parsed.data;
+let cachedPublicEnv: PublicEnv | undefined;
+let cachedEnv: Env | undefined;
+
+export function getPublicEnv(): PublicEnv {
+  cachedPublicEnv ??= parseEnv(publicEnvSchema);
+  return cachedPublicEnv;
+}
+
+export function getEnv(): Env {
+  cachedEnv ??= parseEnv(envSchema);
+  return cachedEnv;
+}

--- a/backend/config/env.ts
+++ b/backend/config/env.ts
@@ -45,7 +45,7 @@ function parseEnv<T>(schema: z.ZodType<T>): T {
   if (!parsed.success) {
     const missing = parsed.error.issues.map((i) => i.path.join('.'));
     throw new Error(
-      `Missing or invalid environment variables: ${missing.join(', ')}`
+      `필수 환경 변수가 없거나 형식이 올바르지 않습니다: ${missing.join(', ')}`
     );
   }
   return parsed.data;

--- a/backend/infrastructure/auth-utils.ts
+++ b/backend/infrastructure/auth-utils.ts
@@ -1,6 +1,6 @@
 import { headers } from 'next/headers';
-import { auth } from '@/backend/infrastructure/auth';
-import { prisma } from '@/backend/infrastructure/db';
+import { getAuth } from '@/backend/infrastructure/auth';
+import { getPrisma } from '@/backend/infrastructure/db';
 import { AppRole } from '@/backend/generated/prisma/enums';
 
 export type UserContext = {
@@ -11,10 +11,10 @@ export type UserContext = {
 };
 
 export async function getCurrentUser(): Promise<UserContext | null> {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getAuth().api.getSession({ headers: await headers() });
   if (!session) return null;
 
-  const appUser = await prisma.appUser.findUnique({
+  const appUser = await getPrisma().appUser.findUnique({
     where: { id: session.user.id },
     select: { role: true, orgId: true },
   });

--- a/backend/infrastructure/auth.ts
+++ b/backend/infrastructure/auth.ts
@@ -1,65 +1,79 @@
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { nextCookies } from 'better-auth/next-js';
-import { prisma } from '@/backend/infrastructure/db';
-import { env } from '@/backend/config/env';
+import { getPrisma } from '@/backend/infrastructure/db';
+import { getEnv, type Env } from '@/backend/config/env';
 
-const socialProviders = {
-  ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
-    ? {
-        google: {
-          clientId: env.GOOGLE_CLIENT_ID,
-          clientSecret: env.GOOGLE_CLIENT_SECRET,
-        },
-      }
-    : {}),
-  ...(env.FACEBOOK_CLIENT_ID && env.FACEBOOK_CLIENT_SECRET
-    ? {
-        facebook: {
-          clientId: env.FACEBOOK_CLIENT_ID,
-          clientSecret: env.FACEBOOK_CLIENT_SECRET,
-        },
-      }
-    : {}),
-};
+function getSocialProviders(env: Env) {
+  return {
+    ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+      ? {
+          google: {
+            clientId: env.GOOGLE_CLIENT_ID,
+            clientSecret: env.GOOGLE_CLIENT_SECRET,
+          },
+        }
+      : {}),
+    ...(env.FACEBOOK_CLIENT_ID && env.FACEBOOK_CLIENT_SECRET
+      ? {
+          facebook: {
+            clientId: env.FACEBOOK_CLIENT_ID,
+            clientSecret: env.FACEBOOK_CLIENT_SECRET,
+          },
+        }
+      : {}),
+  };
+}
 
-const baseURL = env.BETTER_AUTH_URL;
+type Auth = ReturnType<typeof betterAuth>;
 
-const secret = env.BETTER_AUTH_SECRET;
+let authInstance: Auth | undefined;
 
-export const auth = betterAuth({
-  database: prismaAdapter(prisma, { provider: 'postgresql' }),
-  advanced: {
-    database: {
-      generateId: 'uuid',
+export function getAuth(): Auth {
+  if (authInstance) {
+    return authInstance;
+  }
+
+  const env = getEnv();
+  const prisma = getPrisma();
+  const socialProviders = getSocialProviders(env);
+
+  authInstance = betterAuth({
+    database: prismaAdapter(prisma, { provider: 'postgresql' }),
+    advanced: {
+      database: {
+        generateId: 'uuid',
+      },
     },
-  },
-  emailAndPassword: { enabled: true },
-  ...(Object.keys(socialProviders).length > 0 ? { socialProviders } : {}),
-  secret,
-  baseURL,
-  plugins: [nextCookies()],
-  databaseHooks: {
-    user: {
-      create: {
-        after: async (user) => {
-          try {
-            await prisma.$transaction(async (tx) => {
-              await tx.appUser.create({ data: { id: user.id } });
-              await tx.profilesPublic.create({ data: { userId: user.id } });
-              await tx.profilesPrivate.create({ data: { userId: user.id } });
-            });
-          } catch (error) {
-            console.error('사용자 프로비저닝 실패:', error);
+    emailAndPassword: { enabled: true },
+    ...(Object.keys(socialProviders).length > 0 ? { socialProviders } : {}),
+    secret: env.BETTER_AUTH_SECRET,
+    baseURL: env.BETTER_AUTH_URL,
+    plugins: [nextCookies()],
+    databaseHooks: {
+      user: {
+        create: {
+          after: async (user) => {
             try {
-              await prisma.user.delete({ where: { id: user.id } });
-            } catch (deleteError) {
-              console.error('보상 삭제 실패:', deleteError);
+              await prisma.$transaction(async (tx) => {
+                await tx.appUser.create({ data: { id: user.id } });
+                await tx.profilesPublic.create({ data: { userId: user.id } });
+                await tx.profilesPrivate.create({ data: { userId: user.id } });
+              });
+            } catch (error) {
+              console.error('사용자 프로비저닝 실패:', error);
+              try {
+                await prisma.user.delete({ where: { id: user.id } });
+              } catch (deleteError) {
+                console.error('보상 삭제 실패:', deleteError);
+              }
+              throw error;
             }
-            throw error;
-          }
+          },
         },
       },
     },
-  },
-});
+  });
+
+  return authInstance;
+}

--- a/backend/infrastructure/db.ts
+++ b/backend/infrastructure/db.ts
@@ -1,15 +1,25 @@
 import { PrismaClient } from '@/backend/generated/prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { env } from '@/backend/config/env';
+import { getEnv } from '@/backend/config/env';
 
-const adapter = new PrismaPg({
-  connectionString: env.DATABASE_URL,
-});
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+let prismaClient: PrismaClient | undefined;
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+function createPrismaClient() {
+  const adapter = new PrismaPg({
+    connectionString: getEnv().DATABASE_URL,
+  });
 
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
+  return new PrismaClient({ adapter });
+}
+
+export function getPrisma(): PrismaClient {
+  if (process.env.NODE_ENV === 'production') {
+    prismaClient ??= createPrismaClient();
+    return prismaClient;
+  }
+
+  globalForPrisma.prisma ??= createPrismaClient();
+  return globalForPrisma.prisma;
 }

--- a/backend/use-cases/announcements.ts
+++ b/backend/use-cases/announcements.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 import { notFound } from '@/backend/domain/errors';
 import type { z } from 'zod';
 import type { announcementFilterSchema } from '@/backend/validations/announcement';
@@ -9,28 +9,30 @@ export async function getAnnouncements(
   const { page, pageSize } = filters;
 
   const [items, total] = await Promise.all([
-    prisma.announcement.findMany({
+    getPrisma().announcement.findMany({
       orderBy: [{ isPinned: 'desc' }, { createdAt: 'desc' }],
       skip: (page - 1) * pageSize,
       take: pageSize,
     }),
-    prisma.announcement.count(),
+    getPrisma().announcement.count(),
   ]);
 
   return { items, total, page, pageSize };
 }
 
 export async function getAnnouncementById(id: string) {
-  const announcement = await prisma.announcement.findUnique({ where: { id } });
+  const announcement = await getPrisma().announcement.findUnique({
+    where: { id },
+  });
   if (!announcement) throw notFound('공지사항');
   return announcement;
 }
 
 export async function getAnnouncementNeighbors(id: string) {
-  const current = await prisma.announcement.findUnique({ where: { id } });
+  const current = await getPrisma().announcement.findUnique({ where: { id } });
   if (!current) throw notFound('공지사항');
 
-  const ordered = await prisma.announcement.findMany({
+  const ordered = await getPrisma().announcement.findMany({
     select: { id: true, title: true, isPinned: true, createdAt: true },
     orderBy: [{ isPinned: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }],
   });

--- a/backend/use-cases/applications.ts
+++ b/backend/use-cases/applications.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 import { notFound, conflict } from '@/backend/domain/errors';
 import { assertOwnership } from '@/backend/domain/authorization';
 
@@ -14,17 +14,23 @@ const APPLY_CANDIDATE_INCLUDE = {
 } as const;
 
 export async function createApplication(userId: string, jdId: string) {
-  const jd = await prisma.jobDescription.findUnique({ where: { id: jdId } });
+  const jd = await getPrisma().jobDescription.findUnique({
+    where: { id: jdId },
+  });
   if (!jd) throw notFound('채용공고');
 
-  const existing = await prisma.apply.findFirst({ where: { userId, jdId } });
+  const existing = await getPrisma().apply.findFirst({
+    where: { userId, jdId },
+  });
   if (existing) throw conflict('이미 지원한 채용공고입니다');
 
-  return prisma.apply.create({ data: { userId, jdId, status: 'applied' } });
+  return getPrisma().apply.create({
+    data: { userId, jdId, status: 'applied' },
+  });
 }
 
 export async function withdrawApplication(userId: string, applyId: string) {
-  const apply = await prisma.apply.findUnique({ where: { id: applyId } });
+  const apply = await getPrisma().apply.findUnique({ where: { id: applyId } });
   if (!apply) throw notFound('지원');
 
   assertOwnership(userId, apply.userId);
@@ -33,14 +39,14 @@ export async function withdrawApplication(userId: string, applyId: string) {
     throw conflict('지원 취소는 지원 상태에서만 가능합니다');
   }
 
-  return prisma.apply.update({
+  return getPrisma().apply.update({
     where: { id: applyId },
     data: { status: 'withdrawn' },
   });
 }
 
 export async function getUserApplications(userId: string) {
-  return prisma.apply.findMany({
+  return getPrisma().apply.findMany({
     where: { userId },
     include: {
       jd: {
@@ -56,7 +62,7 @@ export async function getUserApplications(userId: string) {
 }
 
 export async function getApplicationsForJd(jdId: string) {
-  return prisma.apply.findMany({
+  return getPrisma().apply.findMany({
     where: { jdId },
     include: APPLY_CANDIDATE_INCLUDE,
     orderBy: { createdAt: 'desc' },
@@ -64,7 +70,7 @@ export async function getApplicationsForJd(jdId: string) {
 }
 
 export async function getApplicantStats(jdId: string) {
-  return prisma.apply.groupBy({
+  return getPrisma().apply.groupBy({
     by: ['status'],
     where: { jdId },
     _count: { _all: true },

--- a/backend/use-cases/catalog.ts
+++ b/backend/use-cases/catalog.ts
@@ -1,21 +1,21 @@
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 
 export async function getJobFamilies() {
-  return prisma.jobFamily.findMany({
+  return getPrisma().jobFamily.findMany({
     include: { jobs: { orderBy: { sortOrder: 'asc' } } },
     orderBy: { sortOrder: 'asc' },
   });
 }
 
 export async function getJobs(familyId?: string) {
-  return prisma.job.findMany({
+  return getPrisma().job.findMany({
     where: familyId ? { jobFamilyId: familyId } : undefined,
     orderBy: { sortOrder: 'asc' },
   });
 }
 
 export async function searchSkills(query: string) {
-  return prisma.skill.findMany({
+  return getPrisma().skill.findMany({
     where: {
       OR: [
         { displayNameEn: { contains: query, mode: 'insensitive' } },
@@ -31,7 +31,7 @@ export async function searchSkills(query: string) {
 }
 
 export async function getSkillById(id: string) {
-  return prisma.skill.findUnique({
+  return getPrisma().skill.findUnique({
     where: { id },
     include: { aliases: true },
   });

--- a/backend/use-cases/jd-queries.ts
+++ b/backend/use-cases/jd-queries.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 import { notFound } from '@/backend/domain/errors';
 import type { z } from 'zod';
 import type { jobDescriptionFilterSchema } from '@/backend/validations/job-description';
@@ -37,21 +37,21 @@ export async function getJobDescriptions(
       : [{ updatedAt: 'desc' as const }, { id: 'desc' as const }];
 
   const [items, total] = await Promise.all([
-    prisma.jobDescription.findMany({
+    getPrisma().jobDescription.findMany({
       where,
       include: JD_INCLUDE,
       orderBy,
       skip: (page - 1) * pageSize,
       take: pageSize,
     }),
-    prisma.jobDescription.count({ where }),
+    getPrisma().jobDescription.count({ where }),
   ]);
 
   return { items, total, page, pageSize };
 }
 
 export async function getJobDescriptionById(id: string) {
-  const jd = await prisma.jobDescription.findUnique({
+  const jd = await getPrisma().jobDescription.findUnique({
     where: { id },
     include: JD_INCLUDE,
   });

--- a/backend/use-cases/profile.ts
+++ b/backend/use-cases/profile.ts
@@ -1,4 +1,4 @@
-import { prisma } from '@/backend/infrastructure/db';
+import { getPrisma } from '@/backend/infrastructure/db';
 import { notFound, conflict } from '@/backend/domain/errors';
 import { toDateOnlyUtc } from '@/backend/domain/date-only';
 import type { z } from 'zod';
@@ -55,7 +55,7 @@ function toCertificationWriteData(
 }
 
 export async function getFullProfile(userId: string) {
-  const profile = await prisma.appUser.findUnique({
+  const profile = await getPrisma().appUser.findUnique({
     where: { id: userId },
     include: {
       profilePublic: true,
@@ -87,7 +87,7 @@ export async function getProfileForViewer(
       ? { ...baseInclude, profilePrivate: true, attachments: true }
       : baseInclude;
 
-  const profile = await prisma.appUser.findUnique({
+  const profile = await getPrisma().appUser.findUnique({
     where: { id: candidateId },
     include,
   });
@@ -96,7 +96,7 @@ export async function getProfileForViewer(
 }
 
 export async function getProfileBySlug(slug: string) {
-  const profile = await prisma.appUser.findFirst({
+  const profile = await getPrisma().appUser.findFirst({
     where: {
       profilePublic: {
         is: { publicSlug: slug },
@@ -112,7 +112,7 @@ export async function updatePublicProfile(
   userId: string,
   data: z.infer<typeof profilePublicSchema>
 ) {
-  return prisma.profilesPublic.update({
+  return getPrisma().profilesPublic.update({
     where: { userId },
     data: toPublicProfileWriteData(data),
   });
@@ -122,14 +122,14 @@ export async function updatePrivateProfile(
   userId: string,
   data: z.infer<typeof profilePrivateSchema>
 ) {
-  return prisma.profilesPrivate.update({ where: { userId }, data });
+  return getPrisma().profilesPrivate.update({ where: { userId }, data });
 }
 
 export async function addCareer(
   userId: string,
   data: z.infer<typeof profileCareerSchema>
 ) {
-  return prisma.profileCareer.create({
+  return getPrisma().profileCareer.create({
     data: { ...toCareerWriteData(data), userId },
   });
 }
@@ -139,29 +139,29 @@ export async function updateCareer(
   id: string,
   data: z.infer<typeof profileCareerSchema>
 ) {
-  const existing = await prisma.profileCareer.findFirst({
+  const existing = await getPrisma().profileCareer.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('경력');
-  return prisma.profileCareer.update({
+  return getPrisma().profileCareer.update({
     where: { id },
     data: toCareerWriteData(data),
   });
 }
 
 export async function deleteCareer(userId: string, id: string) {
-  const existing = await prisma.profileCareer.findFirst({
+  const existing = await getPrisma().profileCareer.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('경력');
-  return prisma.profileCareer.delete({ where: { id } });
+  return getPrisma().profileCareer.delete({ where: { id } });
 }
 
 export async function addEducation(
   userId: string,
   data: z.infer<typeof profileEducationSchema>
 ) {
-  return prisma.profileEducation.create({
+  return getPrisma().profileEducation.create({
     data: { ...toEducationWriteData(data), userId },
   });
 }
@@ -171,29 +171,29 @@ export async function updateEducation(
   id: string,
   data: z.infer<typeof profileEducationSchema>
 ) {
-  const existing = await prisma.profileEducation.findFirst({
+  const existing = await getPrisma().profileEducation.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('학력');
-  return prisma.profileEducation.update({
+  return getPrisma().profileEducation.update({
     where: { id },
     data: toEducationWriteData(data),
   });
 }
 
 export async function deleteEducation(userId: string, id: string) {
-  const existing = await prisma.profileEducation.findFirst({
+  const existing = await getPrisma().profileEducation.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('학력');
-  return prisma.profileEducation.delete({ where: { id } });
+  return getPrisma().profileEducation.delete({ where: { id } });
 }
 
 export async function addLanguage(
   userId: string,
   data: z.infer<typeof profileLanguageSchema>
 ) {
-  return prisma.profileLanguage.create({ data: { ...data, userId } });
+  return getPrisma().profileLanguage.create({ data: { ...data, userId } });
 }
 
 export async function updateLanguage(
@@ -201,26 +201,26 @@ export async function updateLanguage(
   id: string,
   data: z.infer<typeof profileLanguageSchema>
 ) {
-  const existing = await prisma.profileLanguage.findFirst({
+  const existing = await getPrisma().profileLanguage.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('언어');
-  return prisma.profileLanguage.update({ where: { id }, data });
+  return getPrisma().profileLanguage.update({ where: { id }, data });
 }
 
 export async function deleteLanguage(userId: string, id: string) {
-  const existing = await prisma.profileLanguage.findFirst({
+  const existing = await getPrisma().profileLanguage.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('언어');
-  return prisma.profileLanguage.delete({ where: { id } });
+  return getPrisma().profileLanguage.delete({ where: { id } });
 }
 
 export async function addUrl(
   userId: string,
   data: z.infer<typeof profileUrlSchema>
 ) {
-  return prisma.profileUrl.create({ data: { ...data, userId } });
+  return getPrisma().profileUrl.create({ data: { ...data, userId } });
 }
 
 export async function updateUrl(
@@ -228,22 +228,26 @@ export async function updateUrl(
   id: string,
   data: z.infer<typeof profileUrlSchema>
 ) {
-  const existing = await prisma.profileUrl.findFirst({ where: { id, userId } });
+  const existing = await getPrisma().profileUrl.findFirst({
+    where: { id, userId },
+  });
   if (!existing) throw notFound('URL');
-  return prisma.profileUrl.update({ where: { id }, data });
+  return getPrisma().profileUrl.update({ where: { id }, data });
 }
 
 export async function deleteUrl(userId: string, id: string) {
-  const existing = await prisma.profileUrl.findFirst({ where: { id, userId } });
+  const existing = await getPrisma().profileUrl.findFirst({
+    where: { id, userId },
+  });
   if (!existing) throw notFound('URL');
-  return prisma.profileUrl.delete({ where: { id } });
+  return getPrisma().profileUrl.delete({ where: { id } });
 }
 
 export async function addCertification(
   userId: string,
   data: z.infer<typeof profileCertificationSchema>
 ) {
-  return prisma.profileCertification.create({
+  return getPrisma().profileCertification.create({
     data: { ...toCertificationWriteData(data), userId },
   });
 }
@@ -253,27 +257,27 @@ export async function updateCertification(
   id: string,
   data: z.infer<typeof profileCertificationSchema>
 ) {
-  const existing = await prisma.profileCertification.findFirst({
+  const existing = await getPrisma().profileCertification.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('자격증');
-  return prisma.profileCertification.update({
+  return getPrisma().profileCertification.update({
     where: { id },
     data: toCertificationWriteData(data),
   });
 }
 
 export async function deleteCertification(userId: string, id: string) {
-  const existing = await prisma.profileCertification.findFirst({
+  const existing = await getPrisma().profileCertification.findFirst({
     where: { id, userId },
   });
   if (!existing) throw notFound('자격증');
-  return prisma.profileCertification.delete({ where: { id } });
+  return getPrisma().profileCertification.delete({ where: { id } });
 }
 
 export async function addSkill(userId: string, skillId: string) {
   try {
-    return await prisma.profileSkill.create({ data: { userId, skillId } });
+    return await getPrisma().profileSkill.create({ data: { userId, skillId } });
   } catch (e) {
     if ((e as { code?: string }).code === 'P2002') {
       throw conflict('이미 추가된 스킬입니다');
@@ -283,5 +287,5 @@ export async function addSkill(userId: string, skillId: string) {
 }
 
 export async function deleteSkill(userId: string, skillId: string) {
-  return prisma.profileSkill.deleteMany({ where: { userId, skillId } });
+  return getPrisma().profileSkill.deleteMany({ where: { userId, skillId } });
 }

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -257,6 +257,7 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 프로덕션 이미지는 `Dockerfile` 기준 멀티스테이지 + non-root 실행으로 구성됩니다.
 공개 빌드 변수만 `docker build` 시점에 전달하고, 런타임 시크릿은 컨테이너 시작 시 주입합니다.
+`NEXT_PUBLIC_*` 값은 클라이언트 번들에 빌드 타임에 고정되므로 `docker run -e`로는 바꿀 수 없습니다.
 
 ```bash
 docker build \
@@ -272,9 +273,6 @@ docker run --rm -p 3000:3000 \
   -e DIRECT_URL=postgresql://postgres:postgres@host.docker.internal:54329/vridge_test \
   -e BETTER_AUTH_SECRET=dev-secret-dev-secret-dev-secret \
   -e BETTER_AUTH_URL=http://localhost:3000 \
-  -e NEXT_PUBLIC_APP_URL=http://localhost:3000 \
-  -e NEXT_PUBLIC_GA_MEASUREMENT_ID=G-LOCALTEST \
-  -e NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
   vridge:local
 ```
 

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -253,6 +253,31 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 | `pnpm storybook`         | Storybook 실행 (포트 6006)                           |
 | `pnpm build-storybook`   | Storybook 정적 빌드                                  |
 
+### 프로덕션 컨테이너 빌드 / 실행
+
+프로덕션 이미지는 `Dockerfile` 기준 멀티스테이지 + non-root 실행으로 구성됩니다.
+공개 빌드 변수만 `docker build` 시점에 전달하고, 런타임 시크릿은 컨테이너 시작 시 주입합니다.
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_APP_URL=http://localhost:3000 \
+  --build-arg NEXT_PUBLIC_GA_MEASUREMENT_ID=G-LOCALTEST \
+  --build-arg NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
+  -t vridge:local .
+```
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e DATABASE_URL=postgresql://postgres:postgres@host.docker.internal:54329/vridge_test \
+  -e DIRECT_URL=postgresql://postgres:postgres@host.docker.internal:54329/vridge_test \
+  -e BETTER_AUTH_SECRET=dev-secret-dev-secret-dev-secret \
+  -e BETTER_AUTH_URL=http://localhost:3000 \
+  -e NEXT_PUBLIC_APP_URL=http://localhost:3000 \
+  -e NEXT_PUBLIC_GA_MEASUREMENT_ID=G-LOCALTEST \
+  -e NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
+  vridge:local
+```
+
 ### 테스트 실행 시 필수 환경 변수
 
 ```bash

--- a/docs/k3s-migration.md
+++ b/docs/k3s-migration.md
@@ -63,11 +63,18 @@
 
 ### 앱 전용 변수 — 앱 관리 시크릿 `vridge-env`
 
-| 환경 변수             | 설명                |
-| --------------------- | ------------------- |
-| `BETTER_AUTH_SECRET`  | Better Auth 서명 키 |
-| `BETTER_AUTH_URL`     | 런타임 공개 URL     |
-| `NEXT_PUBLIC_APP_URL` | 빌드 타임 공개 URL  |
+| 환경 변수            | 설명            |
+| -------------------- | --------------- |
+| `BETTER_AUTH_SECRET` | 런타임 시크릿   |
+| `BETTER_AUTH_URL`    | 런타임 공개 URL |
+
+### 공개 빌드 변수 — 컨테이너 이미지 빌드 시점 주입
+
+| 환경 변수                        | 설명                       |
+| -------------------------------- | -------------------------- |
+| `NEXT_PUBLIC_APP_URL`            | 빌드 타임 공개 URL         |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID`  | GA4 측정 ID                |
+| `NEXT_PUBLIC_PRIVACY_POLICY_URL` | 개인정보 처리방침 공개 URL |
 
 > `ssemtle`의 시크릿 및 자격 증명은 `vridge`와 공유하지 않습니다.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ const config = {
     '/.next/',
     '/__tests__/test-utils/',
   ],
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
+  turbopack: {
+    root: process.cwd(),
+  },
   images: {
     dangerouslyAllowSVG: true,
     contentDispositionType: 'attachment',

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@/backend/infrastructure/auth';
+import { getAuth } from '@/backend/infrastructure/auth';
 
 function isStaticAssetPath(pathname: string): boolean {
   return /\.[^/]+$/.test(pathname);
@@ -38,7 +38,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const session = await auth.api.getSession({ headers: request.headers });
+  const session = await getAuth().api.getSession({ headers: request.headers });
 
   // 보호 경로 + 미인증 → 로그인 모달 트리거 (Prompt 12)
   if (!session) {


### PR DESCRIPTION
## 🔥 PR 제목

> feat(task): 프로덕션 컨테이너 빌드 구성 추가

## ✨ 작업 내용

- Next.js standalone 출력과 멀티스테이지 Dockerfile, .dockerignore를 추가해 프로덕션 웹 컨테이너 빌드 경로를 구성했습니다.
- 런타임 시크릿과 빌드 타임 공개 변수를 분리하고, auth/db 초기화를 지연시켜 이미지 빌드 시 `DATABASE_URL`, `BETTER_AUTH_SECRET` 같은 시크릿이 필요하지 않도록 정리했습니다.
- CI에 컨테이너 이미지 빌드 검증 단계를 추가하고, README 및 운영 문서에 컨테이너 빌드/실행 계약을 반영했습니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

```bash
pnpm test
pnpm exec tsc --noEmit
NEXT_PUBLIC_APP_URL=http://localhost:3000 \
NEXT_PUBLIC_GA_MEASUREMENT_ID=G-CITEST123 \
NEXT_PUBLIC_PRIVACY_POLICY_URL=http://localhost/privacy \
pnpm build
DATABASE_URL=postgresql://localhost/runtime_db \
DIRECT_URL=postgresql://localhost/runtime_db \
BETTER_AUTH_SECRET=ci-build-secret-ci-build-secret-1234 \
BETTER_AUTH_URL=http://127.0.0.1:3100 \
NEXT_PUBLIC_APP_URL=http://127.0.0.1:3100 \
NEXT_PUBLIC_GA_MEASUREMENT_ID=G-CITEST123 \
NEXT_PUBLIC_PRIVACY_POLICY_URL=http://127.0.0.1/privacy \
HOSTNAME=127.0.0.1 PORT=3100 \
node .next/standalone/server.js
curl -fsS http://127.0.0.1:3100/healthz
```

## 📸 스크린샷 / 시연 (선택)

N/A (UI 변경 없음)

## 🙏 리뷰어에게 한마디

로컬 Docker 데몬을 사용할 수 없는 환경이라 실제 `docker build`는 CI 단계로 검증하도록 구성했습니다. 대신 standalone 서버 부팅과 `/healthz` 응답까지 로컬에서 확인했습니다.

Closes #5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added production Docker container support with optimized multi-stage builds and standalone output; CI now builds a container image.

* **Documentation**
  * Added README and operational docs with Docker build/run examples and guidance for build-time vs runtime environment variables.

* **Refactor**
  * Improved runtime initialization and environment access patterns to better support containerized deployments.

* **Tests**
  * Added and updated test suites to cover auth, env, and infrastructure lazy-init scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->