### PR TITLE
[T07] CNPG cluster and namespace manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,13 @@ jobs:
 
       - name: Helm 차트 검증
         run: sh scripts/validate-vridge-chart.sh
+
+  k8s-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+      - name: yamllint 설치
+        run: pip install yamllint
+      - name: 매니페스트 검증
+        run: sh scripts/validate-k8s-manifests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
-      - name: yamllint 설치
-        run: pip install yamllint
+      - name: uv 설정
+        uses: astral-sh/setup-uv@v5
       - name: 매니페스트 검증
         run: sh scripts/validate-k8s-manifests.sh

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,57 @@
+# vridge Kubernetes 매니페스트
+
+이 디렉터리에는 vridge 애플리케이션의 네임스페이스 및 CloudNativePG(CNPG) 클러스터 매니페스트가 포함되어 있습니다.
+
+## 파일 목록
+
+| 파일 | 설명 |
+| --- | --- |
+| `namespace.yaml` | `vridge` 네임스페이스 정의 |
+| `cnpg-cluster.yaml` | CNPG PostgreSQL 클러스터 (`vridge-db`) 정의 |
+
+## 적용 순서
+
+네임스페이스를 먼저 적용한 뒤 클러스터를 적용해야 합니다.
+
+```sh
+kubectl apply -f deploy/k8s/namespace.yaml
+kubectl apply -f deploy/k8s/cnpg-cluster.yaml
+```
+
+## CNPG 자동 생성 시크릿
+
+CNPG는 클러스터가 준비되면 `vridge-db-app` 시크릿을 자동으로 생성합니다. 이 시크릿은 `bootstrap.initdb`에 지정한 `owner`/`database` 쌍을 기반으로 만들어지며 다음 키를 포함합니다.
+
+| 키 | 설명 |
+| --- | --- |
+| `uri` | PostgreSQL 연결 URI (`postgresql://...`) |
+| `jdbc-uri` | JDBC 형식 연결 문자열 |
+| `pgpass` | pgpass 파일 형식 자격증명 |
+| `password` | 데이터베이스 사용자 비밀번호 |
+| `username` | 데이터베이스 사용자 이름 |
+
+vridge Helm 차트는 `vridge-db-app:uri` 키를 `DATABASE_URL` 및 `DIRECT_URL` 환경변수에 주입합니다.
+
+## 클러스터 준비 상태 확인
+
+```sh
+kubectl get cluster vridge-db -n vridge
+```
+
+`STATUS` 컬럼이 `Cluster in healthy state`로 표시되면 준비된 것입니다.
+
+## 시크릿 생성 확인
+
+```sh
+kubectl get secret vridge-db-app -n vridge
+```
+
+## 스토리지 주의사항
+
+k3s의 기본 스토리지 클래스인 `local-path`는 **볼륨 확장을 지원하지 않습니다.** 현재 `storage.size`는 `1Gi`로 설정되어 있습니다. 운영 환경에 맞게 초기 크기를 충분히 설정하거나, 볼륨 확장을 지원하는 스토리지 클래스를 `storage.storageClass`에 명시하세요.
+
+## 추후 작업 (현재 미포함)
+
+- **백업**: `ScheduledBackup` 리소스는 별도 태스크에서 추가할 예정입니다.
+- **PgBouncer**: 커넥션 풀링은 1단계에서 제외되었으며 이후 단계에서 추가됩니다.
+- **postgresql.parameters**: 현재는 CNPG 기본값을 사용합니다. 운영 부하를 관찰한 뒤 필요시 조정합니다.

--- a/deploy/k8s/cnpg-cluster.yaml
+++ b/deploy/k8s/cnpg-cluster.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: vridge-db
+  namespace: vridge
+  labels:
+    app.kubernetes.io/name: vridge
+    app.kubernetes.io/instance: vridge
+    app.kubernetes.io/managed-by: kubectl
+    app.kubernetes.io/component: database
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+
+  bootstrap:
+    initdb:
+      database: vridge
+      owner: vridge
+      # CNPG automatically creates the secret "vridge-db-app" from this owner/database pair.
+      # It contains keys: uri, jdbc-uri, pgpass, password, username.
+      # The vridge Helm chart reads vridge-db-app:uri for DATABASE_URL and DIRECT_URL.
+
+  storage:
+    size: 1Gi
+    # storageClass is intentionally omitted: inherits cluster default (local-path on k3s).
+    # Set explicitly if deploying to a cluster with multiple storage classes.
+    # Note: k3s local-path does not support volume expansion — provision enough upfront.
+
+  monitoring:
+    enablePodMonitor: false
+
+  # No PgBouncer — deferred to a later phase.
+  # No backup — deferred; add a ScheduledBackup resource in a separate task.
+  # No postgresql.parameters — CNPG defaults are appropriate for 1 instance / 1Gi.
+  # No resources block — add after observing baseline usage.

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vridge
+  labels:
+    app.kubernetes.io/name: vridge
+    app.kubernetes.io/instance: vridge
+    app.kubernetes.io/managed-by: kubectl

--- a/scripts/validate-k8s-manifests.sh
+++ b/scripts/validate-k8s-manifests.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+if ! command -v yamllint >/dev/null 2>&1; then
+  echo "yamllint이 필요합니다: pip install yamllint" >&2
+  exit 1
+fi
+
+yamllint -d '{extends: default, rules: {line-length: {max: 120}, comments-indentation: disable}}' \
+  "$ROOT_DIR/deploy/k8s/namespace.yaml" \
+  "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml"
+
+failures=0
+
+assert_contains() {
+  file=$1
+  pattern=$2
+  description=$3
+
+  if grep -q "$pattern" "$file"; then
+    echo "통과: $description"
+  else
+    echo "실패: $description" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains "$ROOT_DIR/deploy/k8s/namespace.yaml" "kind: Namespace" "namespace.yaml에 kind: Namespace 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/namespace.yaml" "name: vridge" "namespace.yaml에 name: vridge 포함"
+
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "apiVersion: postgresql.cnpg.io/v1" "cnpg-cluster.yaml에 올바른 apiVersion 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "kind: Cluster" "cnpg-cluster.yaml에 kind: Cluster 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "name: vridge-db" "cnpg-cluster.yaml에 name: vridge-db 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "namespace: vridge" "cnpg-cluster.yaml에 namespace: vridge 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "database: vridge" "cnpg-cluster.yaml에 database: vridge 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "owner: vridge" "cnpg-cluster.yaml에 owner: vridge 포함"
+assert_contains "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml" "instances: 1" "cnpg-cluster.yaml에 instances: 1 포함"
+
+if [ "$failures" -gt 0 ]; then
+  echo "${failures}개의 검증이 실패했습니다." >&2
+  exit 1
+fi
+
+echo "모든 K8s 매니페스트 검증을 통과했습니다."

--- a/scripts/validate-k8s-manifests.sh
+++ b/scripts/validate-k8s-manifests.sh
@@ -3,12 +3,16 @@ set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
-if ! command -v yamllint >/dev/null 2>&1; then
-  echo "yamllint이 필요합니다: pip install yamllint" >&2
+if command -v yamllint >/dev/null 2>&1; then
+  YAMLLINT=yamllint
+elif command -v uv >/dev/null 2>&1; then
+  YAMLLINT="uv tool run yamllint"
+else
+  echo "yamllint이 필요합니다: uv tool install yamllint" >&2
   exit 1
 fi
 
-yamllint -d '{extends: default, rules: {line-length: {max: 120}, comments-indentation: disable}}' \
+$YAMLLINT -d '{extends: default, rules: {line-length: {max: 120}, comments-indentation: disable}}' \
   "$ROOT_DIR/deploy/k8s/namespace.yaml" \
   "$ROOT_DIR/deploy/k8s/cnpg-cluster.yaml"
 


### PR DESCRIPTION
## 작업 내용

- `deploy/k8s/namespace.yaml` — `vridge` 네임스페이스 매니페스트 추가 (표준 `app.kubernetes.io/*` 레이블 포함)
- `deploy/k8s/cnpg-cluster.yaml` — CNPG `Cluster` 리소스 추가 (`vridge-db`, 1 인스턴스, PostgreSQL 16, 1Gi 스토리지)
  - 부트스트랩: database=vridge, owner=vridge
  - CNPG가 자동 생성하는 `vridge-db-app` 시크릿 설명 인라인 주석 포함
  - PgBouncer 없음 (추후 태스크로 이관)
- `deploy/k8s/README.md` — 적용 순서, 시크릿 키 목록, 준비 상태 확인 방법, 스토리지 주의사항, 이관 항목 설명 (한국어)
- `scripts/validate-k8s-manifests.sh` — yamllint + grep 기반 정적 검증 스크립트 (`uv tool run yamllint` 사용, fake CRD 없음)
- `.github/workflows/ci.yml` — `k8s-manifests` CI 잡 추가

## 테스트

- pnpm test 통과 (553 tests)
- tsc --noEmit 통과
- `sh scripts/validate-k8s-manifests.sh` 로컬 통과 (9개 assertions 모두 pass)

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kubernetes deployment manifests for namespace and database cluster configuration
  * Integrated Kubernetes manifest validation into CI/CD pipeline

* **Documentation**
  * Added guide for Kubernetes deployment configuration, installation steps, and operational procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->