### PR TITLE
fix(ci): GA 및 개인정보 URL 빌드 변수 검증 제거

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,8 +29,6 @@ jobs:
       - name: 공개 빌드 변수 확인
         run: |
           test -n "$NEXT_PUBLIC_APP_URL"
-          test -n "$NEXT_PUBLIC_GA_MEASUREMENT_ID"
-          test -n "$NEXT_PUBLIC_PRIVACY_POLICY_URL"
 
       - name: Docker Buildx 설정
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## 요약

- `NEXT_PUBLIC_GA_MEASUREMENT_ID`, `NEXT_PUBLIC_PRIVACY_POLICY_URL` 두 변수에 대한 `test -n` 검증 제거
- `NEXT_PUBLIC_APP_URL`만 필수 검증으로 유지

## 이유

GA 측정 ID와 개인정보처리방침 URL은 앱 실행에 필수적이지 않아 설정되지 않아도 빌드가 진행될 수 있어야 함. 반면 `NEXT_PUBLIC_APP_URL`은 핵심 기능(OAuth 리다이렉트 등)에 영향을 줄 수 있으므로 유지.

## 테스트 계획

- [ ] 워크플로우 실행 후 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow validation by removing checks for non-critical configuration variables while maintaining validation for essential settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->