### PR TITLE
fix(deploy): Prisma 마이그레이션 종속성 누락 수정 — pnpm deploy로 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/tools/migration/node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+inject-workspace-packages=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,17 @@ RUN corepack enable
 FROM base AS deps
 WORKDIR /app
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml prisma.config.ts ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml prisma.config.ts .npmrc ./
+COPY tools ./tools
 COPY backend/prisma ./backend/prisma
 
 RUN pnpm install --frozen-lockfile
 
-# Separate stage with hoisted linker so Prisma packages are real directories, not pnpm symlinks.
-# Used by the runner stage to copy a self-contained Prisma CLI for the migration Job.
+# Deploy the migration workspace package into an isolated directory.
+# pnpm deploy resolves the complete Prisma transitive dep tree from the workspace lockfile.
+# node-linker=hoisted (tools/migration/.npmrc) ensures real directories for Docker COPY.
 FROM deps AS prisma-migration-deps
-RUN echo "node-linker=hoisted" >> .npmrc && pnpm install --frozen-lockfile
+RUN pnpm --filter=migration deploy --prod /migration-install
 
 FROM base AS builder
 WORKDIR /app
@@ -47,8 +49,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Prisma CLI and schema — used by the Helm pre-upgrade migration Job
 # Copied from prisma-migration-deps (hoisted linker) so packages are real directories, not pnpm symlinks
-COPY --from=prisma-migration-deps --chown=nextjs:nodejs /app/node_modules/prisma ./node_modules/prisma
-COPY --from=prisma-migration-deps --chown=nextjs:nodejs /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=prisma-migration-deps --chown=nextjs:nodejs /migration-install/node_modules ./node_modules
 COPY --from=deps --chown=nextjs:nodejs /app/backend/prisma ./backend/prisma
 
 USER nextjs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 importers:
 
@@ -168,6 +169,12 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+
+  tools/migration:
+    dependencies:
+      prisma:
+        specifier: ^7.3.0
+        version: 7.3.0(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - 'tools/migration'
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/tools/migration/.npmrc
+++ b/tools/migration/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/tools/migration/package.json
+++ b/tools/migration/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "migration",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "prisma": "^7.3.0"
+  }
+}


### PR DESCRIPTION
## 🔥 PR 제목

fix(deploy): Prisma 마이그레이션 종속성 누락 수정 — pnpm deploy로 전환

## ✨ 작업 내용

- **문제**: production CD에서 마이그레이션 Job이 exit code 1로 실패
  - 원인: `@prisma/dev`(`prisma`의 직접 의존성)가 `@prisma/*` 네임스페이스 밖의 패키지 ~15개(`valibot`, `@electric-sql/pglite`, `hono`, `remeda` 등)를 eagerly require하는데, runner 이미지에 해당 패키지들이 복사되지 않음
- **기존 접근**: `node_modules/prisma`와 `node_modules/@prisma`만 선택적으로 복사 → 의존성 누락
- **변경 내용**:
  - `tools/migration` 워크스페이스 패키지 추가 (`prisma`만 의존성으로 선언)
  - `pnpm deploy --prod`로 Prisma 전체 의존성 트리를 워크스페이스 lockfile 기준으로 격리 설치
  - `node-linker=hoisted`(`tools/migration/.npmrc`)로 Docker COPY 가능한 실제 디렉터리 구조 생성
  - `deps` 스테이지에 `COPY tools ./tools` 추가
  - `prisma-migration-deps` 스테이지를 `pnpm --filter=migration deploy --prod /migration-install` 단일 명령으로 교체

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다. (N/A — 코드 변경만)
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

1. `pnpm install --frozen-lockfile` — lockfile 정합성 확인
2. `docker build --build-arg NEXT_PUBLIC_APP_URL=http://localhost:3000 -t vridge:test .` — 빌드 성공 확인
3. `docker run --rm vridge:test node ./node_modules/prisma/build/index.js --version` — valibot 등 모듈 누락 없이 버전 출력 확인
4. PR 머지 → production 배포 → `kubectl logs -n vridge job/vridge-migrate` — 마이그레이션 정상 완료 확인

## 📸 스크린샷 / 시연 (선택)

N/A — Docker 빌드 변경

## 🙏 리뷰어에게 한마디

`pnpm deploy`는 워크스페이스 lockfile을 그대로 사용하므로 의존성 버전이 정확히 고정됩니다. 수동으로 패키지를 열거하는 방식보다 Prisma가 업데이트되어도 의존성 트리가 자동으로 따라옵니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new migration tool and included its dependencies in the build/container flow.
  * Updated workspace configuration to include the migration tooling.
  * Added package and npm configuration to manage the migration tool’s dependency resolution.
  * Adjusted container build to produce an isolated dependency install for migrations.
  * Extended ignore rules to exclude the migration tool’s node_modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->