### PR TITLE
fix(deploy): Prisma schema-engine 바이너리 포함 보장

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN corepack enable
 FROM base AS deps
 WORKDIR /app
 
+RUN apt-get update -y && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml prisma.config.ts .npmrc ./
 COPY tools ./tools
 COPY backend/prisma ./backend/prisma
@@ -17,8 +19,12 @@ RUN pnpm install --frozen-lockfile
 # Deploy the migration workspace package into an isolated directory.
 # pnpm deploy resolves the complete Prisma transitive dep tree from the workspace lockfile.
 # node-linker=hoisted (tools/migration/.npmrc) ensures real directories for Docker COPY.
+# Prisma downloads the native schema engine during install; pnpm deploy rehydrates packages
+# from the store, so copy the materialized engines back into the deployed bundle.
 FROM deps AS prisma-migration-deps
 RUN pnpm --filter=migration deploy --prod /migration-install
+RUN cp -a /app/node_modules/.pnpm/@prisma+engines@*/node_modules/@prisma/engines/. \
+  /migration-install/node_modules/.pnpm/@prisma+engines@*/node_modules/@prisma/engines/
 
 FROM base AS builder
 WORKDIR /app


### PR DESCRIPTION
## 🔥 PR 제목

fix(deploy): Prisma schema-engine 바이너리 포함 보장

## ✨ 작업 내용

- `deps` 스테이지에 OpenSSL을 먼저 설치해 Prisma가 런타임과 동일한 OpenSSL 3 계열 엔진을 받도록 수정했습니다.
- `pnpm deploy` 이후 `@prisma/engines`의 materialized engine 파일을 `/migration-install` 번들로 다시 복사하도록 보강했습니다.
- 이 변경으로 배포 이미지의 `migrate` initContainer에서 `Could not find schema-engine binary` 오류가 발생하지 않도록 맞췄습니다.
- 관련 이슈: #42

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `docker build --target prisma-migration-deps -t vridge-prisma-migration-test .`
- `docker run --rm vridge-prisma-migration-test sh -lc "find /migration-install/node_modules -path '*schema-engine*' | sed -n '1,40p'"`
- `docker run --rm vridge-prisma-migration-test sh -lc "cd /migration-install && ./node_modules/.bin/prisma --version"`
- 위 검증에서 `schema-engine-linux-arm64-openssl-3.0.x`가 포함되고 Prisma CLI가 해당 엔진을 정상 해석하는 것을 확인했습니다.

## 📸 스크린샷 / 시연 (선택)

N/A - Docker 빌드/CLI 검증으로 확인했습니다.

## 🙏 리뷰어에게 한마디

- self-hosted GitHub runner는 amd64이므로 CI에서는 동일 경로로 `schema-engine-debian-openssl-3.0.x`가 생성될 것으로 예상합니다.
- 이번 PR은 배포 이미지의 Prisma 엔진 누락 문제만 최소 범위로 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build configuration for better dependency management and deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->