### PR TITLE
feat(seed): prod_v0_1_demo 시드 스코프 추가 및 배포 자동화

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -80,8 +80,9 @@ function resolveSeedScope(rawScope: string | undefined): SeedScope {
     return rawScope;
   }
 
-  console.warn(`알 수 없는 SEED_SCOPE(${rawScope})로 full 모드를 사용합니다.`);
-  return 'full';
+  throw new Error(
+    `알 수 없는 SEED_SCOPE(${rawScope})입니다. 허용 값: full, prod_v0_1_core3, prod_v0_1_demo`
+  );
 }
 
 const BASE_SAMPLE_JOB_DESCRIPTIONS: SampleJobDescriptionSeed[] = [

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -68,11 +68,15 @@ const SEED_BUILD_CONFIG: SeedBuildConfig = {
 };
 
 const CANONICAL_PASSWORD = '@Aaa111!';
-type SeedScope = 'full' | 'prod_v0_1_core3';
+type SeedScope = 'full' | 'prod_v0_1_core3' | 'prod_v0_1_demo';
 
 function resolveSeedScope(rawScope: string | undefined): SeedScope {
   if (!rawScope) return 'full';
-  if (rawScope === 'full' || rawScope === 'prod_v0_1_core3') {
+  if (
+    rawScope === 'full' ||
+    rawScope === 'prod_v0_1_core3' ||
+    rawScope === 'prod_v0_1_demo'
+  ) {
     return rawScope;
   }
 
@@ -950,6 +954,26 @@ async function main() {
 
     console.log(
       `seed scope(${seedScope}) 완료: families ${families.length}, jobs ${families.reduce((sum, f) => sum + f.jobs.length, 0)}, skills ${skills.length}, users ${coreUsers.length}`
+    );
+    return;
+  }
+
+  if (seedScope === 'prod_v0_1_demo') {
+    const coreUsers = buildCanonicalUsers({
+      orgId: SAMPLE_IDS.org,
+      password: CANONICAL_PASSWORD,
+    });
+
+    await seedJobFamilies(families);
+    await seedSkills(skills);
+    await seedSampleOrg();
+    await seedSampleJobDescriptions(SAMPLE_JOB_DESCRIPTIONS);
+    await seedAnnouncements(SAMPLE_ANNOUNCEMENTS);
+    await seedSampleUsers(coreUsers);
+    await seedSampleCredentialAccounts(coreUsers);
+
+    console.log(
+      `seed scope(${seedScope}) 완료: families ${families.length}, jobs ${families.reduce((sum, f) => sum + f.jobs.length, 0)}, skills ${skills.length}, jds ${SAMPLE_JOB_DESCRIPTIONS.length}, announcements ${SAMPLE_ANNOUNCEMENTS.length}, users ${coreUsers.length}`
     );
     return;
   }

--- a/deploy/helm/vridge/templates/deployment.yaml
+++ b/deploy/helm/vridge/templates/deployment.yaml
@@ -28,8 +28,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.migrations.enabled }}
+      {{- if or .Values.migrations.enabled .Values.seed.enabled }}
       initContainers:
+        {{- if .Values.migrations.enabled }}
         - name: migrate
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -55,8 +56,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.db.name }}
                   key: uri
-      {{- end }}
-      {{- if .Values.seed.enabled }}
+        {{- end }}
+        {{- if .Values.seed.enabled }}
         - name: seed
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -84,6 +85,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secrets.db.name }}
                   key: uri
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ include "vridge.name" . }}
@@ -138,7 +140,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.migrations.enabled }}
+      {{- if or .Values.migrations.enabled .Values.seed.enabled }}
       volumes:
         - name: tmp
           emptyDir: {}

--- a/deploy/helm/vridge/templates/deployment.yaml
+++ b/deploy/helm/vridge/templates/deployment.yaml
@@ -56,6 +56,35 @@ spec:
                   name: {{ .Values.secrets.db.name }}
                   key: uri
       {{- end }}
+      {{- if .Values.seed.enabled }}
+        - name: seed
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - ./node_modules/.bin/prisma
+            - db
+            - seed
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          env:
+            - name: HOME
+              value: /tmp
+            - name: SEED_SCOPE
+              value: {{ .Values.seed.scope }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.db.name }}
+                  key: uri
+            - name: DIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.db.name }}
+                  key: uri
+      {{- end }}
       containers:
         - name: {{ include "vridge.name" . }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"

--- a/deploy/helm/vridge/values.yaml
+++ b/deploy/helm/vridge/values.yaml
@@ -97,3 +97,7 @@ secrets:
 
 migrations:
   enabled: true
+
+seed:
+  enabled: true
+  scope: prod_v0_1_demo

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:test:seed": "sh -c 'set -a; . ./.env.development; set +a; prisma db seed'",
     "db:test:reset": "sh -c 'set -a; . ./.env.development; set +a; printf \"%s\\n\" \"drop schema if exists public cascade;\" \"create schema public;\" | prisma db execute --stdin && prisma db execute --file backend/prisma/bootstrap.sql && prisma db push --accept-data-loss && prisma db seed'",
     "db:prod:seed:v0.1": "sh -c 'SEED_SCOPE=prod_v0_1_core3 prisma db seed'",
+    "db:prod:seed:v0.1:demo": "sh -c 'SEED_SCOPE=prod_v0_1_demo prisma db seed'",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "storybook:smoke": "storybook dev --port 6006 --ci --smoke-test",


### PR DESCRIPTION
## 개요

`prod_v0_1_core3` 스코프는 최소한의 기준 데이터만 시드하여 배포된 사이트가 비어 보이는 문제가 있었습니다. 사전 제작된 샘플 채용공고 4개와 공지사항 2개를 포함하는 새로운 `prod_v0_1_demo` 스코프를 추가하고, 배포 시 자동으로 실행되도록 Helm initContainer로 연결합니다.

Closes #44

## 변경 사항

- `backend/prisma/seed.ts`: `prod_v0_1_demo` 스코프 추가 — 기준 사용자 3명 + 샘플 JD 4개 + 공지사항 2개
- `package.json`: `db:prod:seed:v0.1:demo` npm 스크립트 추가
- `deploy/helm/vridge/values.yaml`: `seed.enabled: true`, `seed.scope: prod_v0_1_demo` 값 추가
- `deploy/helm/vridge/templates/deployment.yaml`: `migrate` initContainer 이후 실행되는 `seed` initContainer 추가

## 멱등성

모든 시드 작업은 Prisma `upsert` 기반으로, 동일 배포를 여러 번 실행해도 중복 데이터가 생성되지 않습니다.

## 테스트 계획

- [ ] `helm lint deploy/helm/vridge` — 오류 없음 확인
- [ ] `helm template vridge deploy/helm/vridge --namespace vridge` — `migrate` → `seed` initContainer 순서 확인
- [ ] `pnpm db:prod:seed:v0.1:demo` 로컬 실행 — JD 4개, 공지사항 2개, 사용자 3명 시드 확인
- [ ] 배포 후 파드 로그에서 seed initContainer 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable demo dataset seeding for production, allowing automatic initialization of sample orgs, users, job descriptions and announcements.

* **Chores**
  * Deployment updated to optionally run data seeding during startup.
  * New command to run the demo seeder manually from the project CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->